### PR TITLE
Enable atlas-driven officer portraits

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
 * text=auto eol=lf
 *.png binary
-docs/ -diff
+public/assets/** -diff
+docs/**         -diff

--- a/README.md
+++ b/README.md
@@ -11,3 +11,8 @@ pnpm dev # startet http://localhost:5173
 ```
 
 Taste **E**: führt einen Simulations-Cycle aus und loggt Ereignisse in die Konsole.
+
+## Portrait-Atlanten
+
+Portrait-Atlanten unter `public/assets/orcs/portraits/` (z. B. `set_a.webp`, `set_b.webp`) werden automatisch erkannt.
+Builds für Pages bitte lokal ausführen; CI/PR committed keine `docs/`-Assets.

--- a/src/config/art.ts
+++ b/src/config/art.ts
@@ -1,0 +1,7 @@
+export type ArtSet = 'realistic' | 'legacy';
+
+export const ArtConfig = {
+  active: 'realistic' as ArtSet,
+  base: new URL('assets/orcs/portraits/', import.meta.env.BASE_URL).toString(),
+  atlases: ['set_a.webp', 'set_b.webp'] as const
+} as const;

--- a/src/features/portraits/atlas.ts
+++ b/src/features/portraits/atlas.ts
@@ -1,0 +1,155 @@
+import { ArtConfig } from '../../config/art';
+
+export interface AtlasInfo {
+  url: string;
+  cols: number;
+  rows: number;
+  tile: number;
+  count: number;
+}
+
+export interface AtlasBundle {
+  atlases: AtlasInfo[];
+  totalTiles: number;
+}
+
+const GRID_PREFERENCES: Array<[number, number]> = [
+  [6, 4],
+  [5, 5],
+  [4, 6],
+  [6, 5],
+  [5, 6],
+  [8, 4],
+  [4, 8]
+];
+
+function gcd(a: number, b: number): number {
+  let x = Math.abs(a);
+  let y = Math.abs(b);
+  while (y !== 0) {
+    const t = y;
+    y = x % y;
+    x = t;
+  }
+  return x || 1;
+}
+
+function sniffGrid(width: number, height: number): {
+  cols: number;
+  rows: number;
+  tile: number;
+} {
+  for (const [cols, rows] of GRID_PREFERENCES) {
+    if (width % cols === 0 && height % rows === 0) {
+      const tile = Math.min(width / cols, height / rows);
+      if (tile >= 96 && tile <= 512) {
+        return { cols, rows, tile };
+      }
+    }
+  }
+  const tile = Math.max(64, Math.min(512, gcd(width, height)));
+  return {
+    cols: Math.max(1, Math.round(width / tile)),
+    rows: Math.max(1, Math.round(height / tile)),
+    tile
+  };
+}
+
+async function head(url: string): Promise<boolean> {
+  try {
+    const response = await fetch(url, { method: 'HEAD' });
+    return response.ok;
+  } catch {
+    return false;
+  }
+}
+
+let cachedBundle: AtlasBundle | null | undefined;
+let pendingLoad: Promise<AtlasBundle | null> | null = null;
+
+export async function loadAtlases(): Promise<AtlasBundle | null> {
+  if (cachedBundle !== undefined) {
+    return cachedBundle;
+  }
+  if (pendingLoad) {
+    return pendingLoad;
+  }
+  if (typeof Image === 'undefined') {
+    cachedBundle = null;
+    return cachedBundle;
+  }
+  pendingLoad = (async () => {
+    const atlases: AtlasInfo[] = [];
+    for (const file of ArtConfig.atlases) {
+      const url = ArtConfig.base + file;
+      if (!(await head(url))) continue;
+      const img = new Image();
+      img.decoding = 'async';
+      img.src = url;
+      try {
+        await new Promise<void>((resolve, reject) => {
+          img.onload = () => resolve();
+          img.onerror = () => reject(new Error(`Failed to load atlas: ${url}`));
+        });
+      } catch {
+        continue;
+      }
+      const { cols, rows, tile } = sniffGrid(
+        img.naturalWidth,
+        img.naturalHeight
+      );
+      atlases.push({ url, cols, rows, tile, count: cols * rows });
+    }
+    if (atlases.length === 0) {
+      return null;
+    }
+    return {
+      atlases,
+      totalTiles: atlases.reduce((sum, atlas) => sum + atlas.count, 0)
+    };
+  })()
+    .then((bundle) => {
+      cachedBundle = bundle;
+      return bundle;
+    })
+    .catch(() => {
+      cachedBundle = null;
+      return null;
+    })
+    .finally(() => {
+      pendingLoad = null;
+    });
+  return pendingLoad;
+}
+
+export function hashFNV1a(str: string): number {
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < str.length; i += 1) {
+    hash ^= str.charCodeAt(i);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return hash >>> 0;
+}
+
+export function chooseTileIndex(seed: string, total: number): number {
+  if (total <= 0) return 0;
+  return hashFNV1a(seed) % total;
+}
+
+export function resolveTile(bundle: AtlasBundle, index: number): {
+  atlas: AtlasInfo;
+  col: number;
+  row: number;
+} {
+  let offset = index;
+  for (const atlas of bundle.atlases) {
+    if (offset < atlas.count) {
+      const col = offset % atlas.cols;
+      const row = Math.floor(offset / atlas.cols);
+      return { atlas, col, row };
+    }
+    offset -= atlas.count;
+  }
+  const fallback = bundle.atlases[bundle.atlases.length - 1];
+  return { atlas: fallback, col: 0, row: 0 };
+}

--- a/src/ui/Portrait.tsx
+++ b/src/ui/Portrait.tsx
@@ -1,0 +1,141 @@
+import { getPortraitAsset } from '@sim/portraits';
+import type { Officer } from '@sim/types';
+import { ArtConfig } from '../config/art';
+import {
+  chooseTileIndex,
+  resolveTile,
+  loadAtlases,
+  type AtlasBundle
+} from '../features/portraits/atlas';
+
+export interface PortraitOptions {
+  size?: number;
+  ringColor?: string;
+  dead?: boolean;
+  className?: string;
+}
+
+const DEAD_FILTER = 'grayscale(0.9) brightness(0.85)';
+const DEFAULT_SIZE = 88;
+
+export default class Portrait {
+  readonly element: HTMLDivElement;
+  private officer: Officer;
+  private options: PortraitOptions;
+  private requestToken = 0;
+  private static cachedBundle: AtlasBundle | null | undefined;
+  private static pending: Promise<AtlasBundle | null> | null = null;
+
+  constructor(officer: Officer, options: PortraitOptions = {}) {
+    this.officer = officer;
+    this.options = { ...options };
+    this.element = document.createElement('div');
+    this.element.classList.add('portrait');
+    if (options.className) {
+      options.className
+        .split(' ')
+        .filter(Boolean)
+        .forEach((cls) => this.element.classList.add(cls));
+    }
+    this.element.setAttribute('aria-hidden', 'true');
+    this.element.style.backgroundRepeat = 'no-repeat';
+    this.element.style.backgroundColor = '#1d2531';
+    this.update(officer, options);
+  }
+
+  update(officer: Officer, options: PortraitOptions = {}): void {
+    this.officer = officer;
+    this.options = { ...this.options, ...options };
+    const size = this.options.size ?? DEFAULT_SIZE;
+    this.element.style.width = `${size}px`;
+    this.element.style.height = `${size}px`;
+    if (this.options.ringColor) {
+      this.element.style.boxShadow = `0 0 0 3px ${this.options.ringColor} inset, 0 0 18px ${this.options.ringColor}33`;
+    } else {
+      this.element.style.removeProperty('box-shadow');
+    }
+    const dead = this.options.dead ?? officer.status === 'DEAD';
+    this.element.style.filter = dead ? DEAD_FILTER : 'none';
+    this.requestToken += 1;
+    const currentToken = this.requestToken;
+
+    if (ArtConfig.active !== 'realistic') {
+      this.applyLegacy(officer);
+      return;
+    }
+
+    const bundle = Portrait.cachedBundle;
+    if (bundle) {
+      this.applyRealistic(bundle, officer);
+      return;
+    }
+    if (Portrait.cachedBundle === null) {
+      this.applyLegacy(officer);
+      return;
+    }
+    this.applyLegacy(officer);
+    Portrait.ensureBundle()
+      .then((loaded) => {
+        if (!loaded) return;
+        if (currentToken !== this.requestToken) return;
+        if (ArtConfig.active !== 'realistic') return;
+        this.applyRealistic(loaded, this.officer);
+      })
+      .catch(() => {
+        // Silent fallback to legacy
+      });
+  }
+
+  private applyLegacy(officer: Officer): void {
+    const legacy = getPortraitAsset(officer.portraitSeed);
+    if (legacy) {
+      this.element.style.backgroundImage = `url("${legacy}")`;
+      this.element.style.backgroundSize = 'cover';
+      this.element.style.backgroundPosition = 'center';
+    } else {
+      this.element.style.backgroundImage = 'none';
+      this.element.style.backgroundSize = 'cover';
+      this.element.style.backgroundPosition = 'center';
+    }
+  }
+
+  private applyRealistic(bundle: AtlasBundle, officer: Officer): void {
+    if (bundle.totalTiles <= 0) {
+      this.applyLegacy(officer);
+      return;
+    }
+    const size = this.options.size ?? DEFAULT_SIZE;
+    const seed = `${officer.id}|${officer.name}|${officer.level}|${
+      officer.traits?.join(',') ?? ''
+    }`;
+    const index = chooseTileIndex(seed, bundle.totalTiles);
+    const { atlas, col, row } = resolveTile(bundle, index);
+    const width = atlas.cols * size;
+    const height = atlas.rows * size;
+    this.element.style.backgroundImage = `url("${atlas.url}")`;
+    this.element.style.backgroundSize = `${width}px ${height}px`;
+    this.element.style.backgroundPosition = `-${col * size}px -${row * size}px`;
+  }
+
+  private static ensureBundle(): Promise<AtlasBundle | null> {
+    if (this.cachedBundle !== undefined) {
+      return Promise.resolve(this.cachedBundle);
+    }
+    if (this.pending) {
+      return this.pending;
+    }
+    this.pending = loadAtlases()
+      .then((bundle) => {
+        this.cachedBundle = bundle;
+        return bundle;
+      })
+      .catch(() => {
+        this.cachedBundle = null;
+        return null;
+      })
+      .finally(() => {
+        this.pending = null;
+      });
+    return this.pending;
+  }
+}

--- a/src/ui/components/officerCard.ts
+++ b/src/ui/components/officerCard.ts
@@ -1,7 +1,7 @@
-import { getPortraitAsset } from '@sim/portraits';
 import type { Officer, RelationshipType } from '@sim/types';
 import type { OfficerTooltip } from '@ui/components/officerTooltip';
 import { measure, flip } from '@ui/utils/flip';
+import Portrait from '@ui/Portrait';
 
 export interface OfficerCardOptions {
   tooltip: OfficerTooltip;
@@ -54,7 +54,7 @@ export class OfficerCard {
   readonly element: HTMLElement;
   private readonly options: OfficerCardOptions;
   private officer: Officer;
-  private readonly portrait: HTMLImageElement;
+  private readonly portrait: Portrait;
   private readonly nameEl: HTMLHeadingElement;
   private readonly levelBadge: HTMLElement;
   private readonly rankBadge: HTMLElement;
@@ -74,13 +74,11 @@ export class OfficerCard {
     this.element.tabIndex = 0;
     this.element.dataset.officerId = officer.id;
 
-    const portraitWrapper = document.createElement('div');
-    portraitWrapper.className = 'officer-card__portrait';
-    this.portrait = document.createElement('img');
-    this.portrait.className = 'officer-card__portrait-img';
-    this.portrait.alt = officer.name;
-    this.portrait.src = getPortraitAsset(officer.portraitSeed);
-    portraitWrapper.appendChild(this.portrait);
+    this.portrait = new Portrait(officer, {
+      size: 96,
+      className: 'officer-card__portrait',
+      dead: officer.status === 'DEAD'
+    });
 
     const content = document.createElement('div');
     content.className = 'officer-card__content';
@@ -141,7 +139,7 @@ export class OfficerCard {
     this.footer.className = 'officer-card__footer';
     content.appendChild(this.footer);
 
-    this.element.append(portraitWrapper, content);
+    this.element.append(this.portrait.element, content);
     this.attachTooltipListeners();
     this.update(officer);
   }
@@ -268,8 +266,7 @@ export class OfficerCard {
     this.officer = officer;
     this.element.dataset.officerId = officer.id;
     this.setRank(officer.rank);
-    this.portrait.src = getPortraitAsset(officer.portraitSeed);
-    this.portrait.alt = officer.name;
+    this.portrait.update(officer, { dead: officer.status === 'DEAD' });
     this.updateMeta(officer);
     this.updateTraits(officer);
     this.updateRelationships(officer);

--- a/src/ui/components/officerCardLegacy.ts
+++ b/src/ui/components/officerCardLegacy.ts
@@ -1,7 +1,7 @@
-import { getPortraitAsset } from '@sim/portraits';
 import type { Officer } from '@sim/types';
 import type { OfficerTooltip } from '@ui/components/officerTooltip';
 import { measure, flip } from '@ui/utils/flip';
+import Portrait from '@ui/Portrait';
 
 export interface OfficerCardLegacyOptions {
   tooltip: OfficerTooltip;
@@ -27,7 +27,7 @@ export class OfficerCardLegacy {
   private readonly statValues = new Map<StatKey, HTMLElement>();
   private readonly traitContainer: HTMLElement;
   private readonly subtitle: HTMLElement;
-  private readonly portrait: HTMLImageElement;
+  private readonly portrait: Portrait;
   private readonly badges: HTMLElement;
   private readonly meritBadge: HTMLElement;
   private readonly levelBadge: HTMLElement;
@@ -41,12 +41,11 @@ export class OfficerCardLegacy {
     this.element.tabIndex = 0;
     this.element.dataset.officerId = officer.id;
 
-    const portraitWrapper = document.createElement('div');
-    portraitWrapper.className = 'officer-card__portrait';
-    this.portrait = document.createElement('img');
-    this.portrait.alt = officer.name;
-    this.portrait.src = getPortraitAsset(officer.portraitSeed);
-    portraitWrapper.appendChild(this.portrait);
+    this.portrait = new Portrait(officer, {
+      size: 96,
+      className: 'officer-card__portrait',
+      dead: officer.status === 'DEAD'
+    });
 
     const body = document.createElement('div');
     body.className = 'officer-card__body';
@@ -105,7 +104,7 @@ export class OfficerCardLegacy {
     body.appendChild(statsGrid);
     body.appendChild(this.badges);
 
-    this.element.appendChild(portraitWrapper);
+    this.element.appendChild(this.portrait.element);
     this.element.appendChild(body);
 
     this.attachTooltipListeners();
@@ -206,8 +205,7 @@ export class OfficerCardLegacy {
   update(officer: Officer): void {
     const previous = this.officer;
     this.officer = officer;
-    this.portrait.src = getPortraitAsset(officer.portraitSeed);
-    this.portrait.alt = officer.name;
+    this.portrait.update(officer, { dead: officer.status === 'DEAD' });
     this.subtitle.textContent = `${officer.rank} • Merit ${Math.round(officer.merit)}`;
     this.levelBadge.textContent = `Level ${officer.level}`;
     this.meritBadge.textContent = `Zyklus ${officer.cycleJoined}`;

--- a/src/ui/components/warcalls/dock.ts
+++ b/src/ui/components/warcalls/dock.ts
@@ -1,10 +1,10 @@
-import { getPortraitAsset } from '@sim/portraits';
 import type { Officer } from '@sim/types';
 import type { Status } from '@state/selectors/warcalls';
 import type {
   WarcallEntry,
   WarcallBucket
 } from '@ui/components/warcalls/types';
+import Portrait from '@ui/Portrait';
 
 export interface WarcallsDockOptions {
   onOpenDetails: (entry: WarcallEntry) => void;
@@ -95,7 +95,7 @@ export class WarcallsDock {
       <p class="warcall-risk">Risiko ${(entry.plan.risk * 100).toFixed(0)}% • ${
         entry.plan.rewardHint ?? 'Unbekannte Beute'
       }</p>
-      <div class="warcall-avatars">${this.renderParticipants(entry.participants)}</div>
+      <div class="warcall-avatars"></div>
       <footer>
         <span class="warcall-timer">Noch ${timeRemaining} Zyklen</span>
         <button type="button">Details</button>
@@ -110,16 +110,27 @@ export class WarcallsDock {
       }
     });
     item.addEventListener('click', () => this.options.onOpenDetails(entry));
+    const avatarHost = item.querySelector<HTMLDivElement>('.warcall-avatars');
+    if (avatarHost) {
+      this.renderParticipants(avatarHost, entry.participants);
+    }
     return item;
   }
 
-  private renderParticipants(participants: Officer[]): string {
-    return participants
-      .map((officer) => {
-        const src = getPortraitAsset(officer.portraitSeed);
-        return `<span class="warcall-avatar" title="${officer.name}"><img src="${src}" alt="${officer.name}"></span>`;
-      })
-      .join('');
+  private renderParticipants(container: HTMLElement, participants: Officer[]): void {
+    container.innerHTML = '';
+    participants.forEach((officer) => {
+      const avatar = new Portrait(officer, {
+        size: 32,
+        className: 'warcall-avatar',
+        dead: officer.status === 'DEAD'
+      });
+      avatar.element.title = officer.name;
+      avatar.element.setAttribute('role', 'img');
+      avatar.element.setAttribute('aria-label', officer.name);
+      avatar.element.setAttribute('aria-hidden', 'false');
+      container.appendChild(avatar.element);
+    });
   }
 
   private resolvePhaseLabel(entry: WarcallEntry): string {

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -350,6 +350,21 @@ button:disabled {
     border-color 200ms ease;
 }
 
+.portrait {
+  position: relative;
+  display: block;
+  width: 88px;
+  height: 88px;
+  border-radius: 12px;
+  background-color: #1d2531;
+  background-repeat: no-repeat;
+  background-position: center;
+  background-size: cover;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  overflow: hidden;
+  transition: filter 160ms ease;
+}
+
 .officer-card[data-rank='king'] {
   --ring-color: var(--ring-king);
   --ring-shadow: rgba(255, 209, 102, 0.4);
@@ -410,15 +425,23 @@ button:disabled {
   aspect-ratio: 1;
   border-radius: 20px;
   overflow: hidden;
+  box-shadow:
+    0 0 0 3px var(--ring-color),
+    0 18px 38px var(--ring-shadow);
+  transition: box-shadow 200ms ease;
+}
+
+.officer-card__portrait::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  pointer-events: none;
   background: radial-gradient(
     circle at 35% 25%,
     rgba(255, 255, 255, 0.12),
     transparent 60%
   );
-  box-shadow:
-    0 0 0 3px var(--ring-color),
-    0 18px 38px var(--ring-shadow);
-  transition: box-shadow 200ms ease;
 }
 
 .officer-card:hover .officer-card__portrait,
@@ -426,16 +449,6 @@ button:disabled {
   box-shadow:
     0 0 0 3px var(--ring-color),
     0 26px 48px var(--ring-shadow);
-}
-
-.officer-card__portrait-img {
-  width: 100%;
-  height: 100%;
-  display: block;
-  object-fit: cover;
-  border-radius: 18px;
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  filter: saturate(1.05);
 }
 
 .officer-card__content {
@@ -1375,23 +1388,24 @@ button:disabled {
 }
 
 .warcall-avatar {
+  position: relative;
   width: 32px;
   height: 32px;
   border-radius: 50%;
-  overflow: hidden;
+  display: inline-block;
+  background-color: #1d2531;
+  background-repeat: no-repeat;
+  background-position: center;
+  background-size: cover;
   border: 2px solid var(--bg-panel);
   box-shadow: 0 0 0 1px var(--border-soft);
   margin-left: -8px;
+  overflow: hidden;
+  flex-shrink: 0;
 }
 
 .warcall-avatar:first-child {
   margin-left: 0;
-}
-
-.warcall-avatar img {
-  width: 100%;
-  height: 100%;
-  display: block;
 }
 
 .warcall-item footer {
@@ -1481,16 +1495,23 @@ button:disabled {
 .warcall-participants__list article {
   display: flex;
   gap: var(--spacing-sm);
+  align-items: center;
   background: rgba(15, 23, 42, 0.7);
   padding: var(--spacing-sm);
   border-radius: 10px;
   border: 1px solid var(--border-soft);
 }
 
-.warcall-participants__list img {
+.warcall-participant-avatar {
   width: 40px;
   height: 40px;
   border-radius: 12px;
+  background-color: #1d2531;
+  background-repeat: no-repeat;
+  background-position: center;
+  background-size: cover;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  flex-shrink: 0;
 }
 
 .warcall-log p {

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />


### PR DESCRIPTION
## Summary
- add an art configuration and atlas loader to detect hosted portrait spritesheets
- introduce a reusable Portrait helper and switch officer cards and warcall UIs to use it
- refresh styles, docs, and git attributes to support atlas portraits without binary diffs

## Testing
- npm run typecheck
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cee27cab5883209f8a3fad53ea4695