### PR TITLE
feat: integrate realistic portrait atlases

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,4 @@
 * text=auto eol=lf
 *.png binary
-docs/ -diff
 public/** -diff
 docs/** -diff

--- a/README.md
+++ b/README.md
@@ -14,4 +14,8 @@ Taste **E**: führt einen Simulations-Cycle aus und loggt Ereignisse in die Kons
 
 ## CI & Format
 
-PRs müssen `npm run format:check` bestehen; bei lokalen Änderungen `npm run format:write` ausführen. Keine Builds/Assets committen.
+PRs müssen `npm run format:check` (führt `prettier --check` aus) bestehen; bei lokalen Änderungen `npm run format:write` ausführen. Keine Builds/Assets in PRs commiten.
+
+## Portrait-Atlanten
+
+Portrait-Atlanten werden automatisch erkannt, wenn unter `public/assets/orcs/portraits/` Dateien `set_a.webp`, `set_b.webp` liegen.

--- a/src/config/art.ts
+++ b/src/config/art.ts
@@ -1,0 +1,15 @@
+export type ArtSet = 'realistic' | 'legacy';
+
+const baseUrl =
+  typeof import.meta !== 'undefined'
+    ? ((import.meta as unknown as { env?: { BASE_URL?: string } }).env
+        ?.BASE_URL ?? '/')
+    : '/';
+
+export const ArtConfig = {
+  active: 'realistic' as ArtSet,
+  base: new URL('assets/orcs/portraits/', baseUrl).toString(),
+  atlases: ['set_a.webp', 'set_b.webp'] as const
+} as const;
+
+export type ArtAtlasFile = (typeof ArtConfig.atlases)[number];

--- a/src/features/portraits/atlas.ts
+++ b/src/features/portraits/atlas.ts
@@ -1,0 +1,137 @@
+import { ArtConfig } from '../../config/art';
+
+export interface AtlasInfo {
+  url: string;
+  cols: number;
+  rows: number;
+  tile: number;
+  count: number;
+}
+
+export interface AtlasBundle {
+  atlases: AtlasInfo[];
+  totalTiles: number;
+}
+
+function gcd(a: number, b: number): number {
+  let x = Math.abs(a);
+  let y = Math.abs(b);
+  while (y) {
+    const t = y;
+    y = x % y;
+    x = t;
+  }
+  return x || 1;
+}
+
+function sniffGrid(
+  width: number,
+  height: number
+): { cols: number; rows: number; tile: number } {
+  const preferred: Array<[number, number]> = [
+    [6, 4],
+    [5, 5],
+    [4, 6],
+    [6, 5],
+    [5, 6],
+    [8, 4],
+    [4, 8]
+  ];
+
+  for (const [cols, rows] of preferred) {
+    if (width % cols === 0 && height % rows === 0) {
+      const tile = Math.min(width / cols, height / rows);
+      if (tile >= 96 && tile <= 512) {
+        return { cols, rows, tile };
+      }
+    }
+  }
+
+  const size = Math.max(64, Math.min(512, gcd(width, height)));
+  return {
+    cols: Math.max(1, Math.round(width / size)),
+    rows: Math.max(1, Math.round(height / size)),
+    tile: size
+  };
+}
+
+async function head(url: string): Promise<boolean> {
+  if (typeof fetch !== 'function') return false;
+  try {
+    const response = await fetch(url, { method: 'HEAD' });
+    return response.ok;
+  } catch {
+    return false;
+  }
+}
+
+async function loadAtlasesOnce(): Promise<AtlasBundle | null> {
+  const atlases: AtlasInfo[] = [];
+
+  for (const file of ArtConfig.atlases) {
+    const url = ArtConfig.base + file;
+    if (!(await head(url))) continue;
+    const img = new Image();
+    img.decoding = 'async';
+    img.src = url;
+    await new Promise<void>((resolve, reject) => {
+      img.onload = () => resolve();
+      img.onerror = () => reject(new Error(`Failed to load atlas: ${url}`));
+    });
+
+    const { cols, rows, tile } = sniffGrid(img.naturalWidth, img.naturalHeight);
+    atlases.push({ url, cols, rows, tile, count: cols * rows });
+  }
+
+  if (atlases.length === 0) return null;
+
+  const totalTiles = atlases.reduce((total, atlas) => total + atlas.count, 0);
+  return { atlases, totalTiles };
+}
+
+let bundlePromise: Promise<AtlasBundle | null> | null = null;
+
+export async function loadAtlases(): Promise<AtlasBundle | null> {
+  if (!bundlePromise) {
+    bundlePromise = loadAtlasesOnce().catch((error) => {
+      bundlePromise = null;
+      throw error;
+    });
+  }
+  return bundlePromise;
+}
+
+export function hashFNV1a(input: string): number {
+  let hash = 0x811c9dc5 | 0;
+  for (let i = 0; i < input.length; i += 1) {
+    hash ^= input.charCodeAt(i);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return hash >>> 0;
+}
+
+export function chooseTileIndex(seed: string, total: number): number {
+  if (total <= 0) return 0;
+  return hashFNV1a(seed) % total;
+}
+
+export function resolveTile(
+  bundle: AtlasBundle,
+  globalIndex: number
+): { atlas: AtlasInfo; col: number; row: number } {
+  let index = globalIndex;
+  for (const atlas of bundle.atlases) {
+    if (index < atlas.count) {
+      const col = index % atlas.cols;
+      const row = Math.floor(index / atlas.cols);
+      return { atlas, col, row };
+    }
+    index -= atlas.count;
+  }
+  const atlas = bundle.atlases[bundle.atlases.length - 1];
+  return { atlas, col: 0, row: 0 };
+}
+
+export function resetAtlasCache(): void {
+  bundlePromise = null;
+}

--- a/src/ui/Portrait.tsx
+++ b/src/ui/Portrait.tsx
@@ -1,0 +1,186 @@
+import type { Officer } from '@sim/types';
+import { getLegacyPortraitUrl } from '@sim/portraits';
+import { ArtConfig } from '../config/art';
+import {
+  chooseTileIndex,
+  loadAtlases,
+  resolveTile,
+  type AtlasBundle
+} from '../features/portraits/atlas';
+
+export interface PortraitProps {
+  officer: Officer;
+  size?: number;
+  ringColor?: string;
+  dead?: boolean;
+  className?: string;
+}
+
+interface ResolvedProps {
+  officer: Officer;
+  size: number;
+  ringColor?: string;
+  dead: boolean;
+  className?: string;
+}
+
+const DEFAULT_SIZE = 88;
+const DEAD_FILTER = 'grayscale(0.9) brightness(0.85)';
+const PLACEHOLDER_COLOR = '#1d2531';
+
+function withAlpha(color: string): string {
+  if (color.startsWith('var(')) return color;
+  if (/^#[0-9a-fA-F]{6}$/u.test(color)) return `${color}33`;
+  return color;
+}
+
+function buildSeed(officer: Officer): string {
+  const traits = Array.isArray(officer.traits) ? officer.traits.join(',') : '';
+  return `${officer.id}|${officer.name}|${officer.level}|${traits}`;
+}
+
+function resolveProps(
+  previous: ResolvedProps | undefined,
+  next: PortraitProps
+): ResolvedProps {
+  return {
+    officer: next.officer,
+    size: next.size ?? previous?.size ?? DEFAULT_SIZE,
+    ringColor: next.ringColor ?? previous?.ringColor,
+    dead: next.dead ?? previous?.dead ?? false,
+    className: next.className ?? previous?.className
+  };
+}
+
+async function ensureAtlasBundle(): Promise<AtlasBundle | null> {
+  try {
+    return await loadAtlases();
+  } catch {
+    return null;
+  }
+}
+
+export default class Portrait {
+  readonly element: HTMLDivElement;
+  private props: ResolvedProps;
+  private requestId = 0;
+  private fallbackImg: HTMLImageElement | null = null;
+  private disposed = false;
+
+  constructor(props: PortraitProps) {
+    this.element = document.createElement('div');
+    this.element.setAttribute('aria-hidden', 'true');
+    this.element.style.backgroundColor = PLACEHOLDER_COLOR;
+    this.element.style.backgroundRepeat = 'no-repeat';
+    this.props = resolveProps(undefined, props);
+    this.applyClassName(this.props.className);
+    this.applyFrame(this.props);
+    void this.render(this.props);
+  }
+
+  update(props: PortraitProps): void {
+    if (this.disposed) return;
+    this.props = resolveProps(this.props, props);
+    this.applyClassName(this.props.className);
+    this.applyFrame(this.props);
+    void this.render(this.props);
+  }
+
+  destroy(): void {
+    this.disposed = true;
+    this.clearFallback();
+    this.element.replaceChildren();
+  }
+
+  private applyClassName(className?: string): void {
+    this.element.className = className ? `portrait ${className}` : 'portrait';
+  }
+
+  private applyFrame(props: ResolvedProps): void {
+    const size = `${props.size}px`;
+    this.element.style.width = size;
+    this.element.style.height = size;
+    this.element.style.filter = props.dead ? DEAD_FILTER : 'none';
+    if (props.ringColor) {
+      const glow = withAlpha(props.ringColor);
+      this.element.style.boxShadow = `0 0 0 3px ${props.ringColor} inset, 0 0 18px ${glow}`;
+    } else {
+      this.element.style.boxShadow = '';
+    }
+  }
+
+  private async render(props: ResolvedProps): Promise<void> {
+    if (ArtConfig.active !== 'realistic') {
+      this.showLegacy(props);
+      return;
+    }
+
+    const requestId = ++this.requestId;
+    const bundle = await ensureAtlasBundle();
+    if (this.disposed || requestId !== this.requestId) return;
+    if (!bundle || bundle.totalTiles === 0) {
+      this.showLegacy(props);
+      return;
+    }
+    this.showAtlas(bundle, props);
+  }
+
+  private showLegacy(props: ResolvedProps): void {
+    const url = getLegacyPortraitUrl(props.officer.portraitSeed);
+    if (url) {
+      this.applyFallback(url);
+    } else {
+      this.applyPlaceholder();
+    }
+  }
+
+  private showAtlas(bundle: AtlasBundle, props: ResolvedProps): void {
+    const { officer, size } = props;
+    const seed = buildSeed(officer);
+    const globalIndex = chooseTileIndex(seed, bundle.totalTiles);
+    const { atlas, col, row } = resolveTile(bundle, globalIndex);
+    this.clearFallback();
+    this.element.style.backgroundImage = `url("${atlas.url}")`;
+    this.element.style.backgroundSize = `${atlas.cols * size}px ${atlas.rows * size}px`;
+    this.element.style.backgroundPosition = `-${col * size}px -${row * size}px`;
+  }
+
+  private applyFallback(url: string): void {
+    if (!this.fallbackImg) {
+      const img = document.createElement('img');
+      img.alt = '';
+      img.loading = 'lazy';
+      img.decoding = 'async';
+      img.style.width = '100%';
+      img.style.height = '100%';
+      img.style.objectFit = 'cover';
+      img.style.display = 'block';
+      img.style.borderRadius = 'inherit';
+      this.element.appendChild(img);
+      this.fallbackImg = img;
+    }
+    this.element.style.backgroundImage = 'none';
+    this.element.style.backgroundSize = '';
+    this.element.style.backgroundPosition = '';
+    this.element.style.backgroundRepeat = 'no-repeat';
+    this.fallbackImg.src = url;
+  }
+
+  private applyPlaceholder(): void {
+    this.clearFallback();
+    this.element.style.backgroundImage = 'none';
+    this.element.style.backgroundSize = '';
+    this.element.style.backgroundPosition = '';
+  }
+
+  private clearFallback(): void {
+    if (this.fallbackImg) {
+      this.fallbackImg.remove();
+      this.fallbackImg = null;
+    }
+  }
+}
+
+export function createPortrait(props: PortraitProps): Portrait {
+  return new Portrait(props);
+}

--- a/src/ui/components/officerCard.ts
+++ b/src/ui/components/officerCard.ts
@@ -1,7 +1,8 @@
-import { getPortraitAsset } from '@sim/portraits';
 import type { Officer, RelationshipType } from '@sim/types';
 import type { OfficerTooltip } from '@ui/components/officerTooltip';
 import { measure, flip } from '@ui/utils/flip';
+import Portrait from '@ui/Portrait';
+import { rankToRingColor } from '@ui/utils/rankColors';
 
 export interface OfficerCardOptions {
   tooltip: OfficerTooltip;
@@ -54,7 +55,7 @@ export class OfficerCard {
   readonly element: HTMLElement;
   private readonly options: OfficerCardOptions;
   private officer: Officer;
-  private readonly portrait: HTMLImageElement;
+  private readonly portrait: Portrait;
   private readonly nameEl: HTMLHeadingElement;
   private readonly levelBadge: HTMLElement;
   private readonly rankBadge: HTMLElement;
@@ -76,11 +77,14 @@ export class OfficerCard {
 
     const portraitWrapper = document.createElement('div');
     portraitWrapper.className = 'officer-card__portrait';
-    this.portrait = document.createElement('img');
-    this.portrait.className = 'officer-card__portrait-img';
-    this.portrait.alt = officer.name;
-    this.portrait.src = getPortraitAsset(officer.portraitSeed);
-    portraitWrapper.appendChild(this.portrait);
+    this.portrait = new Portrait({
+      officer,
+      size: 96,
+      ringColor: rankToRingColor(officer.rank),
+      dead: officer.status === 'DEAD',
+      className: 'officer-card__portrait-img'
+    });
+    portraitWrapper.appendChild(this.portrait.element);
 
     const content = document.createElement('div');
     content.className = 'officer-card__content';
@@ -268,8 +272,13 @@ export class OfficerCard {
     this.officer = officer;
     this.element.dataset.officerId = officer.id;
     this.setRank(officer.rank);
-    this.portrait.src = getPortraitAsset(officer.portraitSeed);
-    this.portrait.alt = officer.name;
+    this.portrait.update({
+      officer,
+      size: 96,
+      ringColor: rankToRingColor(officer.rank),
+      dead: officer.status === 'DEAD',
+      className: 'officer-card__portrait-img'
+    });
     this.updateMeta(officer);
     this.updateTraits(officer);
     this.updateRelationships(officer);

--- a/src/ui/components/officerCardLegacy.ts
+++ b/src/ui/components/officerCardLegacy.ts
@@ -1,7 +1,8 @@
-import { getPortraitAsset } from '@sim/portraits';
 import type { Officer } from '@sim/types';
 import type { OfficerTooltip } from '@ui/components/officerTooltip';
 import { measure, flip } from '@ui/utils/flip';
+import Portrait from '@ui/Portrait';
+import { rankToRingColor } from '@ui/utils/rankColors';
 
 export interface OfficerCardLegacyOptions {
   tooltip: OfficerTooltip;
@@ -27,7 +28,7 @@ export class OfficerCardLegacy {
   private readonly statValues = new Map<StatKey, HTMLElement>();
   private readonly traitContainer: HTMLElement;
   private readonly subtitle: HTMLElement;
-  private readonly portrait: HTMLImageElement;
+  private readonly portrait: Portrait;
   private readonly badges: HTMLElement;
   private readonly meritBadge: HTMLElement;
   private readonly levelBadge: HTMLElement;
@@ -43,10 +44,14 @@ export class OfficerCardLegacy {
 
     const portraitWrapper = document.createElement('div');
     portraitWrapper.className = 'officer-card__portrait';
-    this.portrait = document.createElement('img');
-    this.portrait.alt = officer.name;
-    this.portrait.src = getPortraitAsset(officer.portraitSeed);
-    portraitWrapper.appendChild(this.portrait);
+    this.portrait = new Portrait({
+      officer,
+      size: 96,
+      ringColor: rankToRingColor(officer.rank),
+      dead: officer.status === 'DEAD',
+      className: 'officer-card__portrait-img'
+    });
+    portraitWrapper.appendChild(this.portrait.element);
 
     const body = document.createElement('div');
     body.className = 'officer-card__body';
@@ -206,8 +211,13 @@ export class OfficerCardLegacy {
   update(officer: Officer): void {
     const previous = this.officer;
     this.officer = officer;
-    this.portrait.src = getPortraitAsset(officer.portraitSeed);
-    this.portrait.alt = officer.name;
+    this.portrait.update({
+      officer,
+      size: 96,
+      ringColor: rankToRingColor(officer.rank),
+      dead: officer.status === 'DEAD',
+      className: 'officer-card__portrait-img'
+    });
     this.subtitle.textContent = `${officer.rank} • Merit ${Math.round(officer.merit)}`;
     this.levelBadge.textContent = `Level ${officer.level}`;
     this.meritBadge.textContent = `Zyklus ${officer.cycleJoined}`;

--- a/src/ui/components/warcalls/modal.ts
+++ b/src/ui/components/warcalls/modal.ts
@@ -1,7 +1,7 @@
-import { getPortraitAsset } from '@sim/portraits';
 import type { Officer } from '@sim/types';
 import type { GameMode } from '@state/ui/mode';
 import type { WarcallEntry } from '@ui/components/warcalls/types';
+import Portrait from '@ui/Portrait';
 
 const PHASES: { key: string; label: string }[] = [
   { key: 'prep', label: 'Vorbereitung' },
@@ -74,20 +74,7 @@ export class WarcallModal {
       </section>
       <section class="warcall-participants">
         <h4>Teilnehmer</h4>
-        <div class="warcall-participants__list">
-          ${entry.participants
-            .map((officer) => {
-              const src = getPortraitAsset(officer.portraitSeed);
-              return `<article>
-                <img src="${src}" alt="${officer.name}">
-                <div>
-                  <strong>${officer.name}</strong>
-                  <span>${roleFor(officer, entry)}</span>
-                </div>
-              </article>`;
-            })
-            .join('')}
-        </div>
+        <div class="warcall-participants__list"></div>
       </section>
       <section class="warcall-log">
         <h4>Log</h4>
@@ -103,6 +90,12 @@ export class WarcallModal {
         <button type="button" data-action="sabotage">Sabotieren</button>
       </footer>
     `;
+    const list = container.querySelector<HTMLDivElement>(
+      '.warcall-participants__list'
+    );
+    if (list) {
+      this.renderParticipants(list, entry);
+    }
     const join = container.querySelector<HTMLButtonElement>(
       '[data-action="join"]'
     );
@@ -150,5 +143,27 @@ export class WarcallModal {
     if (this.current) {
       this.render(this.current);
     }
+  }
+
+  private renderParticipants(list: HTMLDivElement, entry: WarcallEntry): void {
+    list.innerHTML = '';
+    entry.participants.forEach((officer) => {
+      const article = document.createElement('article');
+      const portrait = new Portrait({
+        officer,
+        size: 40,
+        dead: officer.status === 'DEAD',
+        className: 'warcall-participant__img'
+      });
+      article.appendChild(portrait.element);
+      const meta = document.createElement('div');
+      const name = document.createElement('strong');
+      name.textContent = officer.name;
+      const role = document.createElement('span');
+      role.textContent = roleFor(officer, entry);
+      meta.append(name, role);
+      article.appendChild(meta);
+      list.appendChild(article);
+    });
   }
 }

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -34,6 +34,23 @@
   box-sizing: border-box;
 }
 
+.portrait {
+  position: relative;
+  overflow: hidden;
+  border-radius: inherit;
+  background-color: #1d2531;
+  background-position: center;
+  background-repeat: no-repeat;
+}
+
+.portrait img {
+  width: 100%;
+  height: 100%;
+  display: block;
+  border-radius: inherit;
+  object-fit: cover;
+}
+
 html,
 body {
   height: 100%;
@@ -431,8 +448,6 @@ button:disabled {
 .officer-card__portrait-img {
   width: 100%;
   height: 100%;
-  display: block;
-  object-fit: cover;
   border-radius: 18px;
   border: 1px solid rgba(255, 255, 255, 0.08);
   filter: saturate(1.05);
@@ -1388,7 +1403,7 @@ button:disabled {
   margin-left: 0;
 }
 
-.warcall-avatar img {
+.warcall-avatar__img {
   width: 100%;
   height: 100%;
   display: block;
@@ -1487,10 +1502,12 @@ button:disabled {
   border: 1px solid var(--border-soft);
 }
 
-.warcall-participants__list img {
+.warcall-participant__img {
   width: 40px;
   height: 40px;
   border-radius: 12px;
+  flex-shrink: 0;
+  display: block;
 }
 
 .warcall-log p {

--- a/src/ui/utils/rankColors.ts
+++ b/src/ui/utils/rankColors.ts
@@ -1,0 +1,13 @@
+import type { Officer } from '@sim/types';
+
+const RING_COLORS: Record<Officer['rank'], string> = {
+  König: '#ffd166',
+  Spieler: '#f4a261',
+  Captain: '#8ecae6',
+  Späher: '#95d5b2',
+  Grunzer: '#adb5bd'
+};
+
+export function rankToRingColor(rank: Officer['rank']): string {
+  return RING_COLORS[rank];
+}


### PR DESCRIPTION
## Summary
- add configuration for local portrait atlases and loader utilities
- introduce a portrait view that slices atlas tiles with legacy fallbacks
- update officer and warcall UIs plus styles to render the new portraits

## Testing
- npm run format:check
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68ceeb9f845c8320aa13142434bc6520