### PR TITLE
feat: enable atlas portraits for officers

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,5 @@
 * text=auto eol=lf
 *.png binary
+# Prevent large generated assets from cluttering diffs
 public/** -diff
 docs/** -diff

--- a/src/config/art.ts
+++ b/src/config/art.ts
@@ -1,43 +1,25 @@
 export type ArtSet = 'realistic' | 'legacy';
 
-function getStorage(): Storage | null {
+function getInitialArt(): ArtSet {
   try {
-    if (typeof localStorage !== 'undefined') {
-      return localStorage;
-    }
+    const raw = localStorage.getItem('art.active');
+    return raw === 'legacy' ? 'legacy' : 'realistic';
   } catch {
-    // Zugriff verweigert (z. B. Safari Private Mode)
+    return 'realistic';
   }
-  return null;
 }
-
-function readActive(storage: Storage | null): ArtSet {
-  if (!storage) return 'realistic';
-  const stored = storage.getItem('art.active');
-  return stored === 'legacy' || stored === 'realistic' ? stored : 'realistic';
-}
-
-const storage = getStorage();
-const baseUrl =
-  typeof import.meta !== 'undefined'
-    ? ((import.meta as unknown as { env?: { BASE_URL?: string } }).env
-        ?.BASE_URL ?? '/')
-    : '/';
 
 export const ArtConfig = {
-  // Standardmäßig echte Portraits aktivieren. Per localStorage übersteuerbar.
-  active: readActive(storage),
-  // Pages-sicherer Basis-Pfad (achtet auf /orcs/ BASE_URL)
-  base: new URL('assets/orcs/portraits/', baseUrl).toString(),
-  // Die beiden bereits hochgeladenen Dateien
+  active: getInitialArt(),
+  base: new URL('assets/orcs/portraits/', import.meta.env.BASE_URL).toString(),
   atlases: ['set_a.webp', 'set_b.webp'] as const
 } as const;
 
 export function setArtMode(mode: ArtSet): void {
   try {
-    storage?.setItem('art.active', mode);
+    localStorage.setItem('art.active', mode);
   } catch {
-    // Ignoriert Storage-Fehler (z. B. wenn Storage voll ist)
+    // ignore storage write errors (e.g. Safari private mode)
   }
   (ArtConfig as { active: ArtSet }).active = mode;
 }

--- a/src/features/portraits/atlas.ts
+++ b/src/features/portraits/atlas.ts
@@ -1,4 +1,4 @@
-import { ArtConfig } from '../../config/art';
+import { ArtConfig } from '@/config/art';
 
 export interface AtlasInfo {
   url: string;
@@ -136,4 +136,14 @@ export function resolveTile(
   }
   const atlas = bundle.atlases[bundle.atlases.length - 1];
   return { atlas, col: 0, row: 0 };
+}
+
+declare global {
+  interface Window {
+    __PORTRAITS__?: any;
+  }
+}
+
+if (import.meta.env.DEV && typeof window !== 'undefined') {
+  (window as Window & { __PORTRAITS__?: any }).__PORTRAITS__ = { loadAtlases };
 }

--- a/src/ui/Portrait.tsx
+++ b/src/ui/Portrait.tsx
@@ -1,12 +1,12 @@
 import type { Officer } from '@sim/types';
 import { getLegacyPortraitUrl } from '@sim/portraits';
-import { ArtConfig } from '../config/art';
+import { ArtConfig } from '@/config/art';
 import {
   chooseTileIndex,
   loadAtlases,
   resolveTile,
   type AtlasBundle
-} from '../features/portraits/atlas';
+} from '@/features/portraits/atlas';
 
 export interface PortraitProps {
   officer: Officer;
@@ -66,6 +66,8 @@ export default class Portrait {
   private requestId = 0;
   private fallbackImg: HTMLImageElement | null = null;
   private disposed = false;
+  private baseClass?: string;
+  private isActive = false;
 
   constructor(props: PortraitProps) {
     this.element = document.createElement('div');
@@ -93,7 +95,19 @@ export default class Portrait {
   }
 
   private applyClassName(className?: string): void {
-    this.element.className = className ? `portrait ${className}` : 'portrait';
+    this.baseClass = className;
+    this.updateClassList();
+  }
+
+  private updateClassList(): void {
+    const classes = ['portrait'];
+    if (this.isActive) {
+      classes.push('portrait--active');
+    }
+    if (this.baseClass) {
+      classes.push(this.baseClass);
+    }
+    this.element.className = classes.join(' ');
   }
 
   private applyFrame(props: ResolvedProps): void {
@@ -126,6 +140,8 @@ export default class Portrait {
   }
 
   private showLegacy(props: ResolvedProps): void {
+    this.isActive = false;
+    this.updateClassList();
     const url = getLegacyPortraitUrl(props.officer.portraitSeed);
     if (url) {
       this.applyFallback(url);
@@ -140,6 +156,8 @@ export default class Portrait {
     const globalIndex = chooseTileIndex(seed, bundle.totalTiles);
     const { atlas, col, row } = resolveTile(bundle, globalIndex);
     this.clearFallback();
+    this.isActive = true;
+    this.updateClassList();
     this.element.style.backgroundImage = `url("${atlas.url}")`;
     this.element.style.backgroundSize = `${atlas.cols * size}px ${atlas.rows * size}px`;
     this.element.style.backgroundPosition = `-${col * size}px -${row * size}px`;
@@ -168,6 +186,8 @@ export default class Portrait {
 
   private applyPlaceholder(): void {
     this.clearFallback();
+    this.isActive = false;
+    this.updateClassList();
     this.element.style.backgroundImage = 'none';
     this.element.style.backgroundSize = '';
     this.element.style.backgroundPosition = '';

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -36,11 +36,16 @@
 
 .portrait {
   position: relative;
+  display: block;
   overflow: hidden;
   border-radius: inherit;
   background-color: #1d2531;
   background-position: center;
   background-repeat: no-repeat;
+}
+
+.portrait--active {
+  background-color: transparent;
 }
 
 .portrait img {

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,6 +12,7 @@
     "outDir": "dist",
     "baseUrl": ".",
     "paths": {
+      "@/*": ["src/*"],
       "@sim/*": ["src/sim/*"],
       "@ui/*": ["src/ui/*"],
       "@state/*": ["src/state/*"],

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
   base: '/orcs/',
   resolve: {
     alias: {
+      '@': resolve(__dirname, 'src'),
       '@sim': resolve(__dirname, 'src/sim'),
       '@ui': resolve(__dirname, 'src/ui'),
       '@state': resolve(__dirname, 'src/state'),


### PR DESCRIPTION
## Summary
- default the art configuration to the realistic portrait atlases and expose the loader for debugging in development
- update the Portrait utility to tag active atlas renders, rely on the new base alias, and align styling for clean fallbacks
- add a Vite environment shim and path alias so the atlas imports stay pages-safe, and document the -diff asset directories

## Testing
- npm run format:write --silent
- npm run lint --silent
- npm run typecheck --silent

------
https://chatgpt.com/codex/tasks/task_e_68cef521a66483209388a441ac72c270