### PR TITLE
feat: switch avatars to portrait atlases

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,4 @@ PRs müssen `npm run format:check` (führt `prettier --check` aus) bestehen; bei
 ## Portrait-Atlanten
 
 Portrait-Atlanten werden automatisch erkannt, wenn unter `public/assets/orcs/portraits/` Dateien `set_a.webp`, `set_b.webp` liegen.
+Die UI rendert standardmäßig diese realistischen Portraits; der alte Generator greift nur, wenn `localStorage["art.active"] = "legacy"` gesetzt ist.

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,5 @@
 import './bootstrap/debugGuard';
+import '@ui/legacy/register';
 import { GameStore } from '@state/store';
 import { FLAGS } from '@state/flags';
 import { UIModeStore, type GameMode } from '@state/ui/mode';

--- a/src/ui/components/officerCard.ts
+++ b/src/ui/components/officerCard.ts
@@ -1,7 +1,7 @@
 import type { Officer, RelationshipType } from '@sim/types';
 import type { OfficerTooltip } from '@ui/components/officerTooltip';
 import { measure, flip } from '@ui/utils/flip';
-import Portrait from '@ui/Portrait';
+import Avatar from '@ui/officer/Avatar';
 import { rankToRingColor } from '@ui/utils/rankColors';
 
 export interface OfficerCardOptions {
@@ -55,7 +55,7 @@ export class OfficerCard {
   readonly element: HTMLElement;
   private readonly options: OfficerCardOptions;
   private officer: Officer;
-  private readonly portrait: Portrait;
+  private readonly avatar: Avatar;
   private readonly nameEl: HTMLHeadingElement;
   private readonly levelBadge: HTMLElement;
   private readonly rankBadge: HTMLElement;
@@ -77,14 +77,14 @@ export class OfficerCard {
 
     const portraitWrapper = document.createElement('div');
     portraitWrapper.className = 'officer-card__portrait';
-    this.portrait = new Portrait({
+    this.avatar = new Avatar({
       officer,
       size: 96,
       ringColor: rankToRingColor(officer.rank),
       dead: officer.status === 'DEAD',
       className: 'officer-card__portrait-img'
     });
-    portraitWrapper.appendChild(this.portrait.element);
+    portraitWrapper.appendChild(this.avatar.element);
 
     const content = document.createElement('div');
     content.className = 'officer-card__content';
@@ -272,7 +272,7 @@ export class OfficerCard {
     this.officer = officer;
     this.element.dataset.officerId = officer.id;
     this.setRank(officer.rank);
-    this.portrait.update({
+    this.avatar.update({
       officer,
       size: 96,
       ringColor: rankToRingColor(officer.rank),

--- a/src/ui/components/officerCardLegacy.ts
+++ b/src/ui/components/officerCardLegacy.ts
@@ -1,7 +1,7 @@
 import type { Officer } from '@sim/types';
 import type { OfficerTooltip } from '@ui/components/officerTooltip';
 import { measure, flip } from '@ui/utils/flip';
-import Portrait from '@ui/Portrait';
+import Avatar from '@ui/officer/Avatar';
 import { rankToRingColor } from '@ui/utils/rankColors';
 
 export interface OfficerCardLegacyOptions {
@@ -28,7 +28,7 @@ export class OfficerCardLegacy {
   private readonly statValues = new Map<StatKey, HTMLElement>();
   private readonly traitContainer: HTMLElement;
   private readonly subtitle: HTMLElement;
-  private readonly portrait: Portrait;
+  private readonly avatar: Avatar;
   private readonly badges: HTMLElement;
   private readonly meritBadge: HTMLElement;
   private readonly levelBadge: HTMLElement;
@@ -44,14 +44,14 @@ export class OfficerCardLegacy {
 
     const portraitWrapper = document.createElement('div');
     portraitWrapper.className = 'officer-card__portrait';
-    this.portrait = new Portrait({
+    this.avatar = new Avatar({
       officer,
       size: 96,
       ringColor: rankToRingColor(officer.rank),
       dead: officer.status === 'DEAD',
       className: 'officer-card__portrait-img'
     });
-    portraitWrapper.appendChild(this.portrait.element);
+    portraitWrapper.appendChild(this.avatar.element);
 
     const body = document.createElement('div');
     body.className = 'officer-card__body';
@@ -211,7 +211,7 @@ export class OfficerCardLegacy {
   update(officer: Officer): void {
     const previous = this.officer;
     this.officer = officer;
-    this.portrait.update({
+    this.avatar.update({
       officer,
       size: 96,
       ringColor: rankToRingColor(officer.rank),

--- a/src/ui/components/warcalls/dock.ts
+++ b/src/ui/components/warcalls/dock.ts
@@ -4,7 +4,7 @@ import type {
   WarcallEntry,
   WarcallBucket
 } from '@ui/components/warcalls/types';
-import Portrait from '@ui/Portrait';
+import Avatar from '@ui/officer/Avatar';
 
 export interface WarcallsDockOptions {
   onOpenDetails: (entry: WarcallEntry) => void;
@@ -131,13 +131,13 @@ export class WarcallsDock {
       const avatar = document.createElement('span');
       avatar.className = 'warcall-avatar';
       avatar.title = officer.name;
-      const portrait = new Portrait({
+      const avatarView = new Avatar({
         officer,
         size: 32,
         dead: officer.status === 'DEAD',
         className: 'warcall-avatar__img'
       });
-      avatar.appendChild(portrait.element);
+      avatar.appendChild(avatarView.element);
       container.appendChild(avatar);
     });
   }

--- a/src/ui/components/warcalls/modal.ts
+++ b/src/ui/components/warcalls/modal.ts
@@ -1,7 +1,7 @@
 import type { Officer } from '@sim/types';
 import type { GameMode } from '@state/ui/mode';
 import type { WarcallEntry } from '@ui/components/warcalls/types';
-import Portrait from '@ui/Portrait';
+import Avatar from '@ui/officer/Avatar';
 
 const PHASES: { key: string; label: string }[] = [
   { key: 'prep', label: 'Vorbereitung' },
@@ -149,13 +149,13 @@ export class WarcallModal {
     list.innerHTML = '';
     entry.participants.forEach((officer) => {
       const article = document.createElement('article');
-      const portrait = new Portrait({
+      const avatarView = new Avatar({
         officer,
         size: 40,
         dead: officer.status === 'DEAD',
         className: 'warcall-participant__img'
       });
-      article.appendChild(portrait.element);
+      article.appendChild(avatarView.element);
       const meta = document.createElement('div');
       const name = document.createElement('strong');
       name.textContent = officer.name;

--- a/src/ui/legacy/LegacyAvatar.tsx
+++ b/src/ui/legacy/LegacyAvatar.tsx
@@ -1,0 +1,116 @@
+import { getLegacyPortraitUrl } from '@sim/portraits';
+import type { PortraitProps } from '@/ui/Portrait';
+
+interface ResolvedProps {
+  officer: PortraitProps['officer'];
+  size: number;
+  ringColor?: string;
+  dead: boolean;
+  className?: string;
+}
+
+const DEFAULT_SIZE = 88;
+const DEAD_FILTER = 'grayscale(0.9) brightness(0.85)';
+const PLACEHOLDER_COLOR = '#1d2531';
+
+function withAlpha(color: string): string {
+  if (color.startsWith('var(')) return color;
+  if (/^#[0-9a-fA-F]{6}$/u.test(color)) return `${color}33`;
+  return color;
+}
+
+function resolveProps(
+  previous: ResolvedProps | undefined,
+  next: PortraitProps
+): ResolvedProps {
+  return {
+    officer: next.officer,
+    size: next.size ?? previous?.size ?? DEFAULT_SIZE,
+    ringColor: next.ringColor ?? previous?.ringColor,
+    dead: next.dead ?? previous?.dead ?? false,
+    className: next.className ?? previous?.className
+  };
+}
+
+export default class LegacyAvatar {
+  readonly element: HTMLDivElement;
+  private props: ResolvedProps;
+  private readonly img: HTMLImageElement;
+  private baseClass?: string;
+  private isActive = false;
+
+  constructor(props: PortraitProps) {
+    this.element = document.createElement('div');
+    this.element.setAttribute('aria-hidden', 'true');
+    this.element.style.backgroundColor = PLACEHOLDER_COLOR;
+    this.img = document.createElement('img');
+    this.img.alt = '';
+    this.img.loading = 'lazy';
+    this.img.decoding = 'async';
+    this.img.style.width = '100%';
+    this.img.style.height = '100%';
+    this.img.style.objectFit = 'cover';
+    this.img.style.display = 'block';
+    this.img.style.borderRadius = 'inherit';
+    this.element.appendChild(this.img);
+    this.props = resolveProps(undefined, props);
+    this.applyClassName(this.props.className);
+    this.applyFrame(this.props);
+    this.render(this.props);
+  }
+
+  update(props: PortraitProps): void {
+    this.props = resolveProps(this.props, props);
+    this.applyClassName(this.props.className);
+    this.applyFrame(this.props);
+    this.render(this.props);
+  }
+
+  destroy(): void {
+    this.img.remove();
+    this.element.replaceChildren();
+  }
+
+  private applyClassName(className?: string): void {
+    this.baseClass = className;
+    this.updateClassList();
+  }
+
+  private applyFrame(props: ResolvedProps): void {
+    const size = `${props.size}px`;
+    this.element.style.width = size;
+    this.element.style.height = size;
+    this.element.style.filter = props.dead ? DEAD_FILTER : 'none';
+    if (props.ringColor) {
+      const glow = withAlpha(props.ringColor);
+      this.element.style.boxShadow = `0 0 0 3px ${props.ringColor} inset, 0 0 18px ${glow}`;
+    } else {
+      this.element.style.boxShadow = '';
+    }
+  }
+
+  private render(props: ResolvedProps): void {
+    const url = getLegacyPortraitUrl(props.officer.portraitSeed);
+    if (url) {
+      this.img.src = url;
+      this.element.style.backgroundColor = 'transparent';
+      this.isActive = true;
+    } else {
+      this.img.removeAttribute('src');
+      this.element.style.backgroundColor = PLACEHOLDER_COLOR;
+      this.isActive = false;
+    }
+    this.updateClassList();
+  }
+
+  private updateClassList(): void {
+    const classes = ['portrait'];
+    if (this.isActive) {
+      classes.push('portrait--active');
+    }
+    if (this.baseClass) {
+      classes.push(this.baseClass);
+    }
+    this.element.className = classes.join(' ');
+  }
+}

--- a/src/ui/legacy/register.ts
+++ b/src/ui/legacy/register.ts
@@ -1,0 +1,16 @@
+import LegacyAvatar from '@/ui/legacy/LegacyAvatar';
+import type { AvatarProps } from '@/ui/officer/Avatar';
+
+declare global {
+  interface Window {
+    __LEGACY_ORC_AVATAR__?: (props: AvatarProps) => LegacyAvatar;
+  }
+}
+
+if (import.meta.env.DEV && typeof window !== 'undefined') {
+  (
+    window as Window & {
+      __LEGACY_ORC_AVATAR__?: (props: AvatarProps) => LegacyAvatar;
+    }
+  ).__LEGACY_ORC_AVATAR__ = (props: AvatarProps) => new LegacyAvatar(props);
+}

--- a/src/ui/officer/Avatar.ts
+++ b/src/ui/officer/Avatar.ts
@@ -1,0 +1,57 @@
+import type { PortraitProps } from '@/ui/Portrait';
+import Portrait from '@/ui/Portrait';
+import LegacyAvatar from '@/ui/legacy/LegacyAvatar';
+import { ArtConfig, type ArtSet } from '@/config/art';
+
+export type AvatarProps = PortraitProps;
+
+type AvatarImpl = {
+  element: HTMLElement;
+  update(props: AvatarProps): void;
+  destroy(): void;
+};
+
+function createImpl(props: AvatarProps, mode: ArtSet): AvatarImpl {
+  if (mode === 'legacy') {
+    return new LegacyAvatar(props);
+  }
+  return new Portrait(props);
+}
+
+export default class Avatar {
+  element: HTMLElement;
+  private impl: AvatarImpl;
+  private mode: ArtSet;
+
+  constructor(props: AvatarProps) {
+    this.mode = ArtConfig.active;
+    this.impl = createImpl(props, this.mode);
+    this.element = this.impl.element;
+  }
+
+  update(props: AvatarProps): void {
+    const nextMode = ArtConfig.active;
+    if (nextMode !== this.mode) {
+      this.swapImpl(props, nextMode);
+      return;
+    }
+    this.impl.update(props);
+  }
+
+  destroy(): void {
+    this.impl.destroy();
+  }
+
+  private swapImpl(props: AvatarProps, nextMode: ArtSet): void {
+    const previousElement = this.element;
+    const parent = previousElement.parentElement;
+    this.impl.destroy();
+    const nextImpl = createImpl(props, nextMode);
+    this.impl = nextImpl;
+    this.mode = nextMode;
+    this.element = nextImpl.element;
+    if (parent) {
+      parent.replaceChild(nextImpl.element, previousElement);
+    }
+  }
+}

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -432,11 +432,7 @@ button:disabled {
   aspect-ratio: 1;
   border-radius: 20px;
   overflow: hidden;
-  background: radial-gradient(
-    circle at 35% 25%,
-    rgba(255, 255, 255, 0.12),
-    transparent 60%
-  );
+  background: none;
   box-shadow:
     0 0 0 3px var(--ring-color),
     0 18px 38px var(--ring-shadow);


### PR DESCRIPTION
## Summary
- add an Avatar facade that delegates to the atlas-based Portrait renderer or the legacy generator
- update officer cards and warcall participant views to render the new Avatar instances
- expose the legacy renderer only for development toggles, clean up avatar styling, and document the portrait usage

## Testing
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68cef9a0da908320bcfa97d6ddc0c099