### PR TITLE
Add cache busting for portrait atlases

### DIFF
--- a/src/config/art.ts
+++ b/src/config/art.ts
@@ -9,11 +9,28 @@ function getInitialArt(): ArtSet {
   }
 }
 
+const PORTRAIT_VERSION = (() => {
+  const value = import.meta.env.VITE_PORTRAITS_VERSION;
+  if (typeof value === 'string' && value.trim()) return value.trim();
+  return '20250215';
+})();
+
+const PORTRAIT_SUFFIX = PORTRAIT_VERSION
+  ? `?v=${encodeURIComponent(PORTRAIT_VERSION)}`
+  : '';
+
 export const ArtConfig = {
   active: getInitialArt(),
   base: new URL('assets/orcs/portraits/', import.meta.env.BASE_URL).toString(),
-  atlases: ['set_a.webp', 'set_b.webp'] as const
+  atlases: ['set_a.webp', 'set_b.webp'] as const,
+  version: PORTRAIT_VERSION
 } as const;
+
+export type AtlasFile = (typeof ArtConfig.atlases)[number];
+
+export function getAtlasUrl(file: AtlasFile) {
+  return ArtConfig.base + file + PORTRAIT_SUFFIX;
+}
 
 export function setArtMode(mode: ArtSet) {
   try {

--- a/src/features/portraits/atlas.ts
+++ b/src/features/portraits/atlas.ts
@@ -1,4 +1,4 @@
-import { ArtConfig } from '@/config/art';
+import { ArtConfig, getAtlasUrl } from '@/config/art';
 
 export interface AtlasInfo {
   url: string;
@@ -46,7 +46,7 @@ function sniffGrid(w: number, h: number) {
 export async function loadAtlases(): Promise<AtlasBundle | null> {
   const atlases: AtlasInfo[] = [];
   for (const file of ArtConfig.atlases) {
-    const url = ArtConfig.base + file;
+    const url = getAtlasUrl(file);
     const img = new Image();
     img.decoding = 'async';
     img.src = url;


### PR DESCRIPTION
## Summary
- add a configurable portrait atlas version and helper to build versioned URLs
- load portrait atlases through the helper so browsers fetch the updated artwork

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68cf22ca407883208b6b168fef0c29d7