### PR TITLE
Normalize portrait base resolution

### DIFF
--- a/src/config/art.ts
+++ b/src/config/art.ts
@@ -9,11 +9,49 @@ function getInitialArt(): ArtSet {
   }
 }
 
+const PORTRAIT_VERSION = (() => {
+  const value = import.meta.env.VITE_PORTRAITS_VERSION;
+  if (typeof value === 'string' && value.trim()) return value.trim();
+  return '20250215';
+})();
+
+function normalizeBaseUrl(value: string | undefined) {
+  const raw = value ?? '/';
+  const isAbsolute = /^[a-zA-Z][a-zA-Z\d+\-.]*:/.test(raw);
+  if (isAbsolute) return raw.endsWith('/') ? raw : `${raw}/`;
+  let prefixed = raw.startsWith('/') ? raw : `/${raw}`;
+  if (!prefixed.endsWith('/')) prefixed += '/';
+  return prefixed;
+}
+
+const PORTRAIT_BASE = (() => {
+  const base = normalizeBaseUrl(import.meta.env.BASE_URL);
+  return `${base}assets/orcs/portraits/`;
+})();
+
+const PORTRAIT_SUFFIX = PORTRAIT_VERSION
+  ? `?v=${encodeURIComponent(PORTRAIT_VERSION)}`
+  : '';
+
+const PORTRAIT_ATLASES = ['set_a.webp', 'set_b.webp'] as const;
+
 export const ArtConfig = {
   active: getInitialArt(),
-  base: new URL('assets/orcs/portraits/', import.meta.env.BASE_URL).toString(),
-  atlases: ['set_a.webp', 'set_b.webp'] as const
-} as const;
+  base: PORTRAIT_BASE,
+  atlases: PORTRAIT_ATLASES,
+  version: PORTRAIT_VERSION
+} satisfies {
+  active: ArtSet;
+  base: string;
+  atlases: typeof PORTRAIT_ATLASES;
+  version: string;
+};
+
+export type AtlasFile = (typeof ArtConfig.atlases)[number];
+
+export function getAtlasUrl(file: AtlasFile) {
+  return ArtConfig.base + file + PORTRAIT_SUFFIX;
+}
 
 export function setArtMode(mode: ArtSet) {
   try {
@@ -21,5 +59,5 @@ export function setArtMode(mode: ArtSet) {
   } catch {
     /* ignore */
   }
-  (ArtConfig as any).active = mode;
+  ArtConfig.active = mode;
 }

--- a/src/features/portraits/atlas.ts
+++ b/src/features/portraits/atlas.ts
@@ -1,4 +1,4 @@
-import { ArtConfig } from '@/config/art';
+import { ArtConfig, getAtlasUrl } from '@/config/art';
 
 export interface AtlasInfo {
   url: string;
@@ -46,7 +46,7 @@ function sniffGrid(w: number, h: number) {
 export async function loadAtlases(): Promise<AtlasBundle | null> {
   const atlases: AtlasInfo[] = [];
   for (const file of ArtConfig.atlases) {
-    const url = ArtConfig.base + file;
+    const url = getAtlasUrl(file);
     const img = new Image();
     img.decoding = 'async';
     img.src = url;


### PR DESCRIPTION
## Summary
- normalize the portrait atlas base path so it always resolves under the public assets directory
- keep using the cache-busting suffix while honoring custom Vite base URLs
- refactor ArtConfig to share the atlas tuple and satisfy TypeScript 5.9 without duplicate property errors

## Testing
- npm run typecheck
- npm run guard:portraits
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68cf22ca407883208b6b168fef0c29d7