### PR TITLE
Version portrait atlases per build

### DIFF
--- a/src/features/portraits/atlas.ts
+++ b/src/features/portraits/atlas.ts
@@ -1,4 +1,4 @@
-import { ArtConfig } from '@/config/art';
+import { ArtConfig, getAtlasUrl } from '@/config/art';
 
 export interface AtlasInfo {
   url: string;
@@ -46,7 +46,7 @@ function sniffGrid(w: number, h: number) {
 export async function loadAtlases(): Promise<AtlasBundle | null> {
   const atlases: AtlasInfo[] = [];
   for (const file of ArtConfig.atlases) {
-    const url = ArtConfig.base + file;
+    const url = getAtlasUrl(file);
     const img = new Image();
     img.decoding = 'async';
     img.src = url;

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,7 @@
 /// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_PORTRAITS_VERSION?: string;
+}
+
+declare const __BUILD_TIME__: string;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,9 +2,26 @@ import { defineConfig } from 'vite';
 import { resolve } from 'node:path';
 import react from '@vitejs/plugin-react-swc';
 
+const buildTime = (() => {
+  const date = new Date();
+  const pad = (n: number) => n.toString().padStart(2, '0');
+  return (
+    `${date.getUTCFullYear()}` +
+    pad(date.getUTCMonth() + 1) +
+    pad(date.getUTCDate()) +
+    'T' +
+    pad(date.getUTCHours()) +
+    pad(date.getUTCMinutes()) +
+    pad(date.getUTCSeconds())
+  );
+})();
+
 export default defineConfig({
   base: '/orcs/',
   plugins: [react()],
+  define: {
+    __BUILD_TIME__: JSON.stringify(buildTime)
+  },
   resolve: {
     alias: {
       '@': resolve(__dirname, 'src'),


### PR DESCRIPTION
## Summary
- capture the UTC build timestamp in Vite config and expose it as a global __BUILD_TIME__ constant
- fall back to the build stamp whenever VITE_PORTRAITS_VERSION is unset so portrait atlas URLs always receive a fresh cache-busting query string
- extend the Vite env typings with the new portrait version env var and build timestamp constant
- inline the build timestamp fallback ternary so Prettier no longer reports syntax errors during format checks

## Testing
- npm run format:check
- npm run typecheck
- npm run guard:portraits
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68cf22ca407883208b6b168fef0c29d7