### PR TITLE
Version portrait atlases per build

### DIFF
--- a/src/config/art.ts
+++ b/src/config/art.ts
@@ -9,11 +9,60 @@ function getInitialArt(): ArtSet {
   }
 }
 
-export const ArtConfig = {
+const rawPortraitVersion = import.meta.env.VITE_PORTRAITS_VERSION;
+let portraitVersion =
+  typeof rawPortraitVersion === 'string' ? rawPortraitVersion.trim() : '';
+
+if (!portraitVersion) {
+  const buildStamp =
+    typeof __BUILD_TIME__ !== 'undefined' ? String(__BUILD_TIME__).trim() : '';
+  if (buildStamp) {
+    portraitVersion = buildStamp;
+  } else {
+    portraitVersion = 'dev';
+  }
+}
+
+const PORTRAIT_VERSION = portraitVersion;
+
+function normalizeBaseUrl(value: string | undefined) {
+  const raw = value ?? '/';
+  const isAbsolute = /^[a-zA-Z][a-zA-Z\d+\-.]*:/.test(raw);
+  if (isAbsolute) return raw.endsWith('/') ? raw : `${raw}/`;
+  let prefixed = raw.startsWith('/') ? raw : `/${raw}`;
+  if (!prefixed.endsWith('/')) prefixed += '/';
+  return prefixed;
+}
+
+const PORTRAIT_BASE = `${normalizeBaseUrl(import.meta.env.BASE_URL)}assets/orcs/portraits/`;
+
+const PORTRAIT_SUFFIX = PORTRAIT_VERSION
+  ? `?v=${encodeURIComponent(PORTRAIT_VERSION)}`
+  : '';
+
+const PORTRAIT_ATLASES = ['set_a.webp', 'set_b.webp'] as const;
+
+type PortraitAtlases = typeof PORTRAIT_ATLASES;
+
+interface PortraitArtConfig {
+  active: ArtSet;
+  base: string;
+  atlases: PortraitAtlases;
+  version: string;
+}
+
+export type AtlasFile = PortraitAtlases[number];
+
+export const ArtConfig: PortraitArtConfig = {
   active: getInitialArt(),
-  base: new URL('assets/orcs/portraits/', import.meta.env.BASE_URL).toString(),
-  atlases: ['set_a.webp', 'set_b.webp'] as const
-} as const;
+  base: PORTRAIT_BASE,
+  atlases: PORTRAIT_ATLASES,
+  version: PORTRAIT_VERSION
+};
+
+export function getAtlasUrl(file: AtlasFile) {
+  return ArtConfig.base + file + PORTRAIT_SUFFIX;
+}
 
 export function setArtMode(mode: ArtSet) {
   try {
@@ -21,5 +70,5 @@ export function setArtMode(mode: ArtSet) {
   } catch {
     /* ignore */
   }
-  (ArtConfig as any).active = mode;
+  ArtConfig.active = mode;
 }

--- a/src/features/portraits/atlas.ts
+++ b/src/features/portraits/atlas.ts
@@ -1,4 +1,4 @@
-import { ArtConfig } from '@/config/art';
+import { ArtConfig, getAtlasUrl } from '@/config/art';
 
 export interface AtlasInfo {
   url: string;
@@ -46,7 +46,7 @@ function sniffGrid(w: number, h: number) {
 export async function loadAtlases(): Promise<AtlasBundle | null> {
   const atlases: AtlasInfo[] = [];
   for (const file of ArtConfig.atlases) {
-    const url = ArtConfig.base + file;
+    const url = getAtlasUrl(file);
     const img = new Image();
     img.decoding = 'async';
     img.src = url;

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,7 @@
 /// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_PORTRAITS_VERSION?: string;
+}
+
+declare const __BUILD_TIME__: string;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,9 +2,26 @@ import { defineConfig } from 'vite';
 import { resolve } from 'node:path';
 import react from '@vitejs/plugin-react-swc';
 
+const buildTime = (() => {
+  const date = new Date();
+  const pad = (n: number) => n.toString().padStart(2, '0');
+  return (
+    `${date.getUTCFullYear()}` +
+    pad(date.getUTCMonth() + 1) +
+    pad(date.getUTCDate()) +
+    'T' +
+    pad(date.getUTCHours()) +
+    pad(date.getUTCMinutes()) +
+    pad(date.getUTCSeconds())
+  );
+})();
+
 export default defineConfig({
   base: '/orcs/',
   plugins: [react()],
+  define: {
+    __BUILD_TIME__: JSON.stringify(buildTime)
+  },
   resolve: {
     alias: {
       '@': resolve(__dirname, 'src'),


### PR DESCRIPTION
## Summary
- capture the UTC build timestamp in Vite config and expose it as a global __BUILD_TIME__ constant
- fall back to the build stamp whenever VITE_PORTRAITS_VERSION is unset so portrait atlas URLs always receive a fresh cache-busting query string
- extend the Vite env typings with the new portrait version env var and build timestamp constant
- refactor the portrait version and base constants so the configuration stays mutable while satisfying Prettier's parser

## Testing
- npm run format:check
- npm run typecheck
- npm run guard:portraits
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68cf22ca407883208b6b168fef0c29d7