### PR TITLE
Remove legacy portrait fallback so new atlases load

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,5 +19,5 @@ PRs müssen `npm run format:check` (führt `prettier --check` aus) bestehen; bei
 ## Portrait-Atlanten
 
 Portrait-Atlanten werden automatisch erkannt, wenn unter `public/assets/orcs/portraits/` Dateien `set_a.webp`, `set_b.webp` liegen.
-Avatare nutzen diese Atlanten (`set_a.webp`, `set_b.webp`); Legacy-Grafik nur, falls `localStorage['art.active'] = 'legacy'` gesetzt ist.
+Avatare nutzen ausschließlich diese Atlanten; eine Versionsnummer sorgt dafür, dass neue Builds die Browser-Caches aktualisieren.
 CI prüft via `npm run guard:portraits`, dass keine alten Generator-Imports mehr eingebunden werden.

--- a/src/features/portraits/atlas.ts
+++ b/src/features/portraits/atlas.ts
@@ -1,4 +1,4 @@
-import { ArtConfig } from '@/config/art';
+import { ArtConfig, getAtlasUrl } from '@/config/art';
 
 export interface AtlasInfo {
   url: string;
@@ -46,7 +46,7 @@ function sniffGrid(w: number, h: number) {
 export async function loadAtlases(): Promise<AtlasBundle | null> {
   const atlases: AtlasInfo[] = [];
   for (const file of ArtConfig.atlases) {
-    const url = ArtConfig.base + file;
+    const url = getAtlasUrl(file);
     const img = new Image();
     img.decoding = 'async';
     img.src = url;

--- a/src/ui/officer/Avatar.tsx
+++ b/src/ui/officer/Avatar.tsx
@@ -1,21 +1,11 @@
 import { createElement } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
-import { ArtConfig } from '@/config/art';
 import Portrait, { type PortraitProps } from '@/ui/Portrait';
 
 export type AvatarProps = PortraitProps;
 
 /** Einziger erlaubter Einstiegspunkt für Offiziersbilder. */
 export default function Avatar(props: AvatarProps) {
-  if (ArtConfig.active === 'legacy') {
-    const Legacy =
-      typeof window !== 'undefined'
-        ? ((window as any).__LEGACY_ORC_AVATAR__ as
-            | ((p: AvatarProps) => JSX.Element)
-            | undefined)
-        : undefined;
-    if (Legacy) return Legacy(props);
-  }
   return <Portrait {...props} />;
 }
 

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,7 @@
 /// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_PORTRAITS_VERSION?: string;
+}
+
+declare const __BUILD_TIME__: string;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,9 +2,26 @@ import { defineConfig } from 'vite';
 import { resolve } from 'node:path';
 import react from '@vitejs/plugin-react-swc';
 
+const buildTime = (() => {
+  const date = new Date();
+  const pad = (n: number) => n.toString().padStart(2, '0');
+  return (
+    `${date.getUTCFullYear()}` +
+    pad(date.getUTCMonth() + 1) +
+    pad(date.getUTCDate()) +
+    'T' +
+    pad(date.getUTCHours()) +
+    pad(date.getUTCMinutes()) +
+    pad(date.getUTCSeconds())
+  );
+})();
+
 export default defineConfig({
   base: '/orcs/',
   plugins: [react()],
+  define: {
+    __BUILD_TIME__: JSON.stringify(buildTime)
+  },
   resolve: {
     alias: {
       '@': resolve(__dirname, 'src'),


### PR DESCRIPTION
## Summary
- drop the localStorage-driven legacy art toggle and associated exports from the portrait config
- always render the new portrait component for officers so atlas URLs point at the refreshed assets
- document that officer avatars now exclusively use the public atlases with automatic cache busting

## Testing
- npm run format:check
- npm run typecheck
- npm run guard:portraits
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68cf22ca407883208b6b168fef0c29d7