### PR TITLE
Add Free Roam test mode with procedural map

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,6 +16,9 @@ function resolveInitialMode(): GameMode {
   if (modeParam === 'player' && FLAGS.PLAYER_MODE) {
     return 'player';
   }
+  if (modeParam === 'freeRoam') {
+    return 'freeRoam';
+  }
   return 'spectate';
 }
 

--- a/src/features/freeRoam/FreeRoamView.tsx
+++ b/src/features/freeRoam/FreeRoamView.tsx
@@ -1,0 +1,173 @@
+import { useEffect, useMemo, useRef } from 'react';
+import type { GameStore } from '@state/store';
+import type { UIModeStore } from '@state/ui/mode';
+import type { Phase } from '@state/selectors/warcalls';
+import Portrait from '@/ui/Portrait';
+import { renderWorldMap } from '@/map/render';
+import type { Biome } from '@/map/generator';
+import {
+  DEFAULT_IDLE_MS,
+  DEFAULT_OFFICER_LIMIT,
+  DEFAULT_MAP_SIZE,
+  useFreeRoam
+} from './useFreeRoam';
+
+const PHASE_LABEL: Record<Phase, string> = {
+  prep: 'Vorbereitung',
+  travel: 'Auf dem Weg',
+  event: 'Ereignis',
+  resolution: 'Auflösung'
+};
+
+const BIOME_LABEL: Record<Biome, string> = {
+  desert: 'Wüste',
+  plains: 'Ebene',
+  forest: 'Wald',
+  swamp: 'Sumpf',
+  tundra: 'Tundra',
+  ashwastes: 'Aschelande',
+  volcano: 'Vulkan',
+  river: 'Fluss'
+};
+
+interface FreeRoamViewProps {
+  store: GameStore;
+  modeStore: UIModeStore;
+}
+
+export function FreeRoamView({ store, modeStore }: FreeRoamViewProps) {
+  const idleMs = DEFAULT_IDLE_MS;
+  const { map, warcalls, officers, cycle, idleSeconds } = useFreeRoam(store, {
+    mapSize: DEFAULT_MAP_SIZE,
+    officerLimit: DEFAULT_OFFICER_LIMIT,
+    idleMs
+  });
+
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    renderWorldMap(canvas, map);
+  }, [map]);
+
+  const secondsUntilCycle = useMemo(() => {
+    const total = Math.ceil(idleMs / 1000);
+    return Math.max(0, total - idleSeconds);
+  }, [idleMs, idleSeconds]);
+
+  const handleExit = () => {
+    modeStore.setMode('spectate');
+  };
+
+  const handleAdvanceCycle = () => {
+    store.tick();
+  };
+
+  return (
+    <div className="free-roam">
+      <header className="free-roam__hud">
+        <div className="free-roam__title">
+          <h1>Free Roam (Test)</h1>
+          <p>Erkunde die Nemesis-Simulation direkt auf der Weltkarte.</p>
+        </div>
+        <div className="free-roam__status">
+          <span>Zyklus {cycle}</span>
+          <span>Nächster Auto-Cycle in {secondsUntilCycle}s</span>
+        </div>
+        <div className="free-roam__actions">
+          <button type="button" onClick={handleAdvanceCycle}>
+            Cycle auslösen
+          </button>
+          <button type="button" onClick={handleExit}>
+            Zurück
+          </button>
+        </div>
+      </header>
+      <div className="free-roam__body">
+        <div className="free-roam__stage">
+          <canvas ref={canvasRef} className="free-roam__canvas" />
+          <div className="free-roam__overlay">
+            {warcalls.map((entry) => (
+              <div
+                key={entry.warcall.id}
+                className={`free-roam__marker free-roam__marker--warcall free-roam__marker--${entry.warcall.phase}`}
+                style={{
+                  left: `${entry.xPercent}%`,
+                  top: `${entry.yPercent}%`
+                }}
+                title={`${entry.warcall.kind} — ${entry.warcall.location}`}
+              >
+                <span className="free-roam__marker-icon">⚔️</span>
+              </div>
+            ))}
+            {officers.map((entry) => (
+              <div
+                key={entry.officer.id}
+                className="free-roam__marker free-roam__marker--officer"
+                style={{
+                  left: `${entry.xPercent}%`,
+                  top: `${entry.yPercent}%`
+                }}
+                title={`${entry.officer.name} • ${BIOME_LABEL[entry.coordinate.biome]}`}
+              >
+                <Portrait
+                  officer={entry.officer}
+                  size={48}
+                  className="free-roam__marker-avatar"
+                />
+                <span className="free-roam__marker-label">
+                  {entry.officer.name}
+                </span>
+              </div>
+            ))}
+          </div>
+        </div>
+        <aside className="free-roam__sidebar">
+          <section className="free-roam__panel">
+            <h2>Aktive Warcalls</h2>
+            {warcalls.length === 0 ? (
+              <p className="free-roam__empty">Keine aktiven Warcalls.</p>
+            ) : (
+              <ul className="free-roam__list">
+                {warcalls.map((entry) => (
+                  <li key={entry.warcall.id} className="free-roam__list-item">
+                    <div className="free-roam__list-title">
+                      <strong>{entry.warcall.kind}</strong>
+                      <span> • {entry.warcall.location}</span>
+                    </div>
+                    <div className="free-roam__list-meta">
+                      {PHASE_LABEL[entry.warcall.phase]} •{' '}
+                      {entry.warcall.participants.length} Teilnehmer
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </section>
+          <section className="free-roam__panel">
+            <h2>Offiziere im Blick</h2>
+            {officers.length === 0 ? (
+              <p className="free-roam__empty">Keine Offiziere verfügbar.</p>
+            ) : (
+              <ul className="free-roam__list">
+                {officers.map((entry) => (
+                  <li key={entry.officer.id} className="free-roam__list-item">
+                    <div className="free-roam__list-title">
+                      <strong>{entry.officer.name}</strong>
+                      <span> • {entry.officer.rank}</span>
+                    </div>
+                    <div className="free-roam__list-meta">
+                      Merit {Math.round(entry.officer.merit)} •{' '}
+                      {BIOME_LABEL[entry.coordinate.biome]}
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </section>
+        </aside>
+      </div>
+    </div>
+  );
+}

--- a/src/features/freeRoam/useFreeRoam.ts
+++ b/src/features/freeRoam/useFreeRoam.ts
@@ -1,0 +1,162 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import type { Officer, WorldState } from '@sim/types';
+import type { GameStore } from '@state/store';
+import { generateWorldMap, type WorldMap } from '@/map/generator';
+import { findOpenTile, toPercent, type MapCoordinate } from '@/map/navgrid';
+import {
+  selectActiveOfficers,
+  selectActiveWarcalls
+} from '@/sim/adapters/freeRoam.selectors';
+import type { WarcallWithPhase } from '@state/selectors/warcalls';
+
+export interface PositionedWarcall {
+  warcall: WarcallWithPhase;
+  coordinate: MapCoordinate;
+  xPercent: number;
+  yPercent: number;
+}
+
+export interface PositionedOfficer {
+  officer: Officer;
+  coordinate: MapCoordinate;
+  xPercent: number;
+  yPercent: number;
+}
+
+interface FreeRoamSnapshot {
+  cycle: number;
+  warcalls: PositionedWarcall[];
+  officers: PositionedOfficer[];
+}
+
+export interface UseFreeRoamOptions {
+  mapSize?: number;
+  officerLimit?: number;
+  idleMs?: number;
+}
+
+export interface FreeRoamState extends FreeRoamSnapshot {
+  map: WorldMap;
+  idleSeconds: number;
+}
+
+export const DEFAULT_IDLE_MS = 60_000;
+export const DEFAULT_MAP_SIZE = 256;
+export const DEFAULT_OFFICER_LIMIT = 20;
+
+function computeSnapshot(
+  world: WorldState,
+  map: WorldMap,
+  officerLimit: number
+): FreeRoamSnapshot {
+  const warcalls = selectActiveWarcalls(world);
+  const officers = selectActiveOfficers(world, officerLimit);
+  const occupied = new Set<number>();
+
+  const positionedWarcalls: PositionedWarcall[] = warcalls.map((warcall) => {
+    const coordinate = findOpenTile(
+      map,
+      `${warcall.id}:${warcall.location}:${warcall.resolveOn}`,
+      occupied
+    );
+    return {
+      warcall,
+      coordinate,
+      xPercent: toPercent(map, coordinate.x),
+      yPercent: toPercent(map, coordinate.y)
+    };
+  });
+
+  const positionedOfficers: PositionedOfficer[] = officers.map((officer) => {
+    const key = `${officer.stableId ?? officer.id}`;
+    const coordinate = findOpenTile(map, key, occupied);
+    return {
+      officer,
+      coordinate,
+      xPercent: toPercent(map, coordinate.x),
+      yPercent: toPercent(map, coordinate.y)
+    };
+  });
+
+  return {
+    cycle: world.cycle,
+    warcalls: positionedWarcalls,
+    officers: positionedOfficers
+  };
+}
+
+export function useFreeRoam(
+  store: GameStore,
+  options: UseFreeRoamOptions = {}
+): FreeRoamState {
+  const mapSize = options.mapSize ?? DEFAULT_MAP_SIZE;
+  const officerLimit = options.officerLimit ?? DEFAULT_OFFICER_LIMIT;
+  const idleMs = options.idleMs ?? DEFAULT_IDLE_MS;
+
+  const map = useMemo(() => {
+    const initial = store.getState();
+    return generateWorldMap(initial.seed, mapSize);
+  }, [store, mapSize]);
+
+  const [snapshot, setSnapshot] = useState<FreeRoamSnapshot>(() =>
+    computeSnapshot(store.getState(), map, officerLimit)
+  );
+  const [idleSeconds, setIdleSeconds] = useState(0);
+  const lastInteractionRef = useRef(Date.now());
+
+  useEffect(() => {
+    setSnapshot(computeSnapshot(store.getState(), map, officerLimit));
+  }, [store, map, officerLimit]);
+
+  useEffect(() => {
+    const unsubscribe = store.events.on('state:changed', (world) => {
+      setSnapshot(computeSnapshot(world, map, officerLimit));
+    });
+    return () => unsubscribe();
+  }, [store, map, officerLimit]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return undefined;
+    const markInteraction = () => {
+      lastInteractionRef.current = Date.now();
+      setIdleSeconds(0);
+    };
+    const events: (keyof WindowEventMap)[] = [
+      'pointerdown',
+      'pointermove',
+      'keydown',
+      'wheel',
+      'touchstart'
+    ];
+    events.forEach((event) =>
+      window.addEventListener(event, markInteraction, { passive: true })
+    );
+    return () => {
+      events.forEach((event) =>
+        window.removeEventListener(event, markInteraction)
+      );
+    };
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return undefined;
+    const interval = window.setInterval(() => {
+      const now = Date.now();
+      const elapsed = now - lastInteractionRef.current;
+      const seconds = Math.floor(elapsed / 1000);
+      setIdleSeconds(seconds);
+      if (elapsed >= idleMs) {
+        lastInteractionRef.current = now;
+        setIdleSeconds(0);
+        store.tick();
+      }
+    }, 1000);
+    return () => window.clearInterval(interval);
+  }, [store, idleMs]);
+
+  return {
+    map,
+    idleSeconds,
+    ...snapshot
+  };
+}

--- a/src/map/generator.ts
+++ b/src/map/generator.ts
@@ -1,0 +1,193 @@
+import { RNG } from '@sim/rng';
+
+export type Biome =
+  | 'desert'
+  | 'plains'
+  | 'forest'
+  | 'swamp'
+  | 'tundra'
+  | 'ashwastes'
+  | 'volcano'
+  | 'river';
+
+export interface WorldMap {
+  seed: string;
+  size: number;
+  tiles: Biome[];
+  height: Float32Array;
+  temperature: Float32Array;
+  moisture: Float32Array;
+}
+
+interface LayerConfig {
+  scale: number;
+  weight: number;
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max);
+}
+
+function lerp(a: number, b: number, t: number): number {
+  return a + (b - a) * t;
+}
+
+function sampleLayer(seed: string, size: number, scale: number): Float32Array {
+  if (scale <= 0) {
+    const fill = new Float32Array(size * size);
+    fill.fill(0.5);
+    return fill;
+  }
+  const rng = new RNG(`${seed}:layer:${scale}`);
+  const coarseSize = scale + 1;
+  const coarse = new Float32Array(coarseSize * coarseSize);
+  for (let i = 0; i < coarse.length; i += 1) {
+    coarse[i] = rng.next();
+  }
+  const field = new Float32Array(size * size);
+  for (let y = 0; y < size; y += 1) {
+    const gy = (y / (size - 1)) * scale;
+    const y0 = Math.floor(gy);
+    const y1 = Math.min(scale, y0 + 1);
+    const fy = gy - y0;
+    for (let x = 0; x < size; x += 1) {
+      const gx = (x / (size - 1)) * scale;
+      const x0 = Math.floor(gx);
+      const x1 = Math.min(scale, x0 + 1);
+      const fx = gx - x0;
+      const idx00 = y0 * coarseSize + x0;
+      const idx10 = y0 * coarseSize + x1;
+      const idx01 = y1 * coarseSize + x0;
+      const idx11 = y1 * coarseSize + x1;
+      const v00 = coarse[idx00];
+      const v10 = coarse[idx10];
+      const v01 = coarse[idx01];
+      const v11 = coarse[idx11];
+      const top = lerp(v00, v10, fx);
+      const bottom = lerp(v01, v11, fx);
+      field[y * size + x] = lerp(top, bottom, fy);
+    }
+  }
+  return field;
+}
+
+function normalize(field: Float32Array): Float32Array {
+  let min = Number.POSITIVE_INFINITY;
+  let max = Number.NEGATIVE_INFINITY;
+  for (let i = 0; i < field.length; i += 1) {
+    const value = field[i];
+    if (value < min) min = value;
+    if (value > max) max = value;
+  }
+  const range = max - min || 1;
+  const normalized = new Float32Array(field.length);
+  for (let i = 0; i < field.length; i += 1) {
+    normalized[i] = (field[i] - min) / range;
+  }
+  return normalized;
+}
+
+function buildField(
+  seed: string,
+  size: number,
+  layers: LayerConfig[]
+): Float32Array {
+  const field = new Float32Array(size * size);
+  const totalWeight = layers.reduce((sum, layer) => sum + layer.weight, 0) || 1;
+  layers.forEach((layer, index) => {
+    const noise = sampleLayer(`${seed}:${index}`, size, layer.scale);
+    for (let i = 0; i < field.length; i += 1) {
+      field[i] += noise[i] * layer.weight;
+    }
+  });
+  for (let i = 0; i < field.length; i += 1) {
+    field[i] /= totalWeight;
+  }
+  return normalize(field);
+}
+
+function resolveBiome(
+  height: number,
+  moisture: number,
+  temperature: number
+): Biome {
+  if (height < 0.18) return 'river';
+  if (height > 0.92 && temperature > 0.55) return 'volcano';
+  if (height > 0.88 && temperature < 0.45) return 'tundra';
+  if (temperature < 0.18) {
+    return height > 0.45 ? 'tundra' : 'swamp';
+  }
+  if (temperature < 0.32 && height > 0.6) {
+    return 'tundra';
+  }
+  if (temperature > 0.82 && moisture < 0.35) {
+    return 'desert';
+  }
+  if (height > 0.75 && moisture < 0.4 && temperature > 0.55) {
+    return 'ashwastes';
+  }
+  if (moisture > 0.78 && height < 0.65) {
+    return 'swamp';
+  }
+  if (moisture > 0.6) {
+    return 'forest';
+  }
+  if (height > 0.83 && temperature > 0.5) {
+    return 'ashwastes';
+  }
+  if (height > 0.9) {
+    return temperature > 0.6 ? 'volcano' : 'tundra';
+  }
+  return 'plains';
+}
+
+export function generateWorldMap(seed: string, size: number = 256): WorldMap {
+  const baseSeed = `${seed}:free-roam-map`;
+  const heightField = buildField(baseSeed, size, [
+    { scale: 8, weight: 0.5 },
+    { scale: 16, weight: 0.3 },
+    { scale: 32, weight: 0.2 }
+  ]);
+  const moistureNoise = buildField(`${baseSeed}:moisture`, size, [
+    { scale: 10, weight: 0.6 },
+    { scale: 24, weight: 0.4 }
+  ]);
+  const temperatureNoise = buildField(`${baseSeed}:temperature`, size, [
+    { scale: 12, weight: 0.5 },
+    { scale: 28, weight: 0.5 }
+  ]);
+
+  const moisture = new Float32Array(size * size);
+  const temperature = new Float32Array(size * size);
+  const tiles: Biome[] = new Array(size * size);
+
+  for (let y = 0; y < size; y += 1) {
+    const lat = y / (size - 1 || 1);
+    for (let x = 0; x < size; x += 1) {
+      const index = y * size + x;
+      const height = heightField[index];
+      const moistureValue = clamp(
+        moistureNoise[index] * 0.6 + (1 - height) * 0.4,
+        0,
+        1
+      );
+      const temperatureValue = clamp(
+        lat * 0.7 + temperatureNoise[index] * 0.3,
+        0,
+        1
+      );
+      moisture[index] = moistureValue;
+      temperature[index] = temperatureValue;
+      tiles[index] = resolveBiome(height, moistureValue, temperatureValue);
+    }
+  }
+
+  return {
+    seed,
+    size,
+    tiles,
+    height: heightField,
+    temperature,
+    moisture
+  };
+}

--- a/src/map/navgrid.ts
+++ b/src/map/navgrid.ts
@@ -1,0 +1,49 @@
+import { RNG } from '@sim/rng';
+import type { Biome, WorldMap } from './generator';
+
+export interface MapCoordinate {
+  x: number;
+  y: number;
+  index: number;
+  biome: Biome;
+}
+
+export function isPassable(biome: Biome): boolean {
+  return biome !== 'river';
+}
+
+export function toPercent(map: WorldMap, value: number): number {
+  return ((value + 0.5) / map.size) * 100;
+}
+
+export function findOpenTile(
+  map: WorldMap,
+  key: string,
+  occupied: Set<number>,
+  attempts = 120
+): MapCoordinate {
+  const rng = new RNG(`${map.seed}:nav:${key}`);
+  for (let attempt = 0; attempt < attempts; attempt += 1) {
+    const x = rng.int(0, map.size - 1);
+    const y = rng.int(0, map.size - 1);
+    const index = y * map.size + x;
+    const biome = map.tiles[index];
+    if (!occupied.has(index) && isPassable(biome)) {
+      occupied.add(index);
+      return { x, y, index, biome };
+    }
+  }
+
+  for (let index = 0; index < map.tiles.length; index += 1) {
+    if (occupied.has(index)) continue;
+    const biome = map.tiles[index];
+    if (!isPassable(biome)) continue;
+    const x = index % map.size;
+    const y = Math.floor(index / map.size);
+    occupied.add(index);
+    return { x, y, index, biome };
+  }
+
+  occupied.add(0);
+  return { x: 0, y: 0, index: 0, biome: map.tiles[0] ?? 'plains' };
+}

--- a/src/map/render.ts
+++ b/src/map/render.ts
@@ -1,0 +1,60 @@
+import type { Biome, WorldMap } from './generator';
+
+export const BIOME_COLORS: Record<Biome, string> = {
+  desert: '#d7a86b',
+  plains: '#5fa463',
+  forest: '#2f6f3b',
+  swamp: '#244836',
+  tundra: '#a9c2d9',
+  ashwastes: '#5b5463',
+  volcano: '#c34632',
+  river: '#3b6fc1'
+};
+
+function hexToRgb(hex: string): [number, number, number] {
+  const normalized = hex.replace('#', '');
+  const bigint = Number.parseInt(normalized, 16);
+  const r = (bigint >> 16) & 255;
+  const g = (bigint >> 8) & 255;
+  const b = bigint & 255;
+  return [r, g, b];
+}
+
+function clamp01(value: number): number {
+  if (value < 0) return 0;
+  if (value > 1) return 1;
+  return value;
+}
+
+export function renderWorldMap(
+  canvas: HTMLCanvasElement,
+  map: WorldMap,
+  palette: Partial<Record<Biome, string>> = {}
+): void {
+  const context = canvas.getContext('2d');
+  if (!context) return;
+
+  if (canvas.width !== map.size || canvas.height !== map.size) {
+    canvas.width = map.size;
+    canvas.height = map.size;
+  }
+
+  const imageData = context.createImageData(map.size, map.size);
+  const { data } = imageData;
+
+  for (let i = 0; i < map.tiles.length; i += 1) {
+    const biome = map.tiles[i];
+    const baseColor = palette[biome] ?? BIOME_COLORS[biome];
+    const [r, g, b] = hexToRgb(baseColor);
+    const height = map.height[i];
+    const moisture = map.moisture[i];
+    const shade = clamp01(0.75 + height * 0.3 - moisture * 0.1);
+    const index = i * 4;
+    data[index] = Math.round(r * shade);
+    data[index + 1] = Math.round(g * shade);
+    data[index + 2] = Math.round(b * shade);
+    data[index + 3] = 255;
+  }
+
+  context.putImageData(imageData, 0, 0);
+}

--- a/src/sim/adapters/freeRoam.selectors.ts
+++ b/src/sim/adapters/freeRoam.selectors.ts
@@ -1,0 +1,72 @@
+import type { Officer, WorldState } from '@sim/types';
+import {
+  selectWarcallsByStatus,
+  type WarcallWithPhase
+} from '@state/selectors/warcalls';
+
+const DEFAULT_OFFICER_LIMIT = 20;
+
+export function selectActiveWarcalls(state: WorldState): WarcallWithPhase[] {
+  return selectWarcallsByStatus(state, 'active');
+}
+
+function sortOfficersByMerit(officers: Officer[]): Officer[] {
+  return [...officers].sort(
+    (a, b) =>
+      b.merit - a.merit ||
+      b.level - a.level ||
+      a.name.localeCompare(b.name, 'de-DE')
+  );
+}
+
+export function selectActiveOfficers(
+  state: WorldState,
+  limit: number = DEFAULT_OFFICER_LIMIT
+): Officer[] {
+  const alive = state.officers.filter((officer) => officer.status === 'ALIVE');
+  if (alive.length === 0) {
+    return [];
+  }
+
+  const byId = new Map(alive.map((officer) => [officer.id, officer] as const));
+  const selected: Officer[] = [];
+  const seen = new Set<string>();
+
+  const activeWarcalls = selectActiveWarcalls(state);
+  activeWarcalls.forEach((warcall) => {
+    const initiator = byId.get(warcall.initiator);
+    if (initiator && !seen.has(initiator.id)) {
+      selected.push(initiator);
+      seen.add(initiator.id);
+    }
+    warcall.participants.forEach((participantId) => {
+      if (seen.has(participantId)) return;
+      const participant = byId.get(participantId);
+      if (participant) {
+        selected.push(participant);
+        seen.add(participant.id);
+      }
+    });
+  });
+
+  const king = byId.get(state.kingId);
+  if (king && !seen.has(king.id)) {
+    selected.push(king);
+    seen.add(king.id);
+  }
+
+  if (selected.length >= limit) {
+    return selected.slice(0, limit);
+  }
+
+  const remainder = sortOfficersByMerit(
+    alive.filter((officer) => !seen.has(officer.id))
+  );
+  for (const officer of remainder) {
+    if (selected.length >= limit) break;
+    selected.push(officer);
+    seen.add(officer.id);
+  }
+
+  return selected.slice(0, limit);
+}

--- a/src/state/ui/mode.ts
+++ b/src/state/ui/mode.ts
@@ -1,6 +1,6 @@
 import { EventBus } from '@state/eventBus';
 
-export type GameMode = 'spectate' | 'player';
+export type GameMode = 'spectate' | 'player' | 'freeRoam';
 
 export interface UIModeState {
   mode: GameMode;
@@ -12,8 +12,8 @@ interface UIModeEvents extends Record<string, UIModeState> {
 }
 
 function normalizeState(state: UIModeState): UIModeState {
-  if (state.mode === 'spectate') {
-    return { mode: 'spectate', playerId: null };
+  if (state.mode !== 'player') {
+    return { mode: state.mode, playerId: null };
   }
   return state;
 }

--- a/src/ui/components/modeGate.ts
+++ b/src/ui/components/modeGate.ts
@@ -7,7 +7,8 @@ interface ModeGateOptions {
 
 const MODE_LABEL: Record<GameMode, string> = {
   spectate: 'Spectate',
-  player: 'Player'
+  player: 'Player',
+  freeRoam: 'Free Roam (Test)'
 };
 
 export class ModeGate {
@@ -17,6 +18,7 @@ export class ModeGate {
   private readonly startButton: HTMLButtonElement;
   private readonly spectateButton: HTMLButtonElement;
   private readonly playerButton: HTMLButtonElement;
+  private readonly freeRoamButton: HTMLButtonElement;
 
   constructor(options: ModeGateOptions) {
     this.options = options;
@@ -33,6 +35,10 @@ export class ModeGate {
           <button type="button" data-mode="spectate" class="is-active">
             <span class="mode-gate__mode">Spectate</span>
             <span class="mode-gate__hint">Standardmodus • Keine Spielerfigur</span>
+          </button>
+          <button type="button" data-mode="freeRoam">
+            <span class="mode-gate__mode">Free Roam (Test)</span>
+            <span class="mode-gate__hint">Simulation live auf Karte ansehen</span>
           </button>
           <button type="button" data-mode="player" ${
             FLAGS.PLAYER_MODE ? '' : 'class="is-disabled" disabled'
@@ -56,6 +62,9 @@ export class ModeGate {
     ) as HTMLButtonElement;
     this.playerButton = this.element.querySelector(
       'button[data-mode="player"]'
+    ) as HTMLButtonElement;
+    this.freeRoamButton = this.element.querySelector(
+      'button[data-mode="freeRoam"]'
     ) as HTMLButtonElement;
     this.registerEvents();
     this.close();
@@ -95,6 +104,10 @@ export class ModeGate {
       this.selection = 'spectate';
       this.syncSelection();
     });
+    this.freeRoamButton.addEventListener('click', () => {
+      this.selection = 'freeRoam';
+      this.syncSelection();
+    });
     this.playerButton.addEventListener('click', () => {
       if (!FLAGS.PLAYER_MODE) return;
       this.selection = 'player';
@@ -115,6 +128,10 @@ export class ModeGate {
     this.spectateButton.classList.toggle(
       'is-active',
       this.selection === 'spectate'
+    );
+    this.freeRoamButton.classList.toggle(
+      'is-active',
+      this.selection === 'freeRoam'
     );
     const playerActive = this.selection === 'player';
     this.playerButton.classList.toggle('is-active', playerActive);

--- a/src/ui/components/warcalls/modal.ts
+++ b/src/ui/components/warcalls/modal.ts
@@ -116,7 +116,7 @@ export class WarcallModal {
       const disabled = spectateDisabled || resolved;
       button.disabled = disabled;
       if (spectateDisabled) {
-        button.title = 'Im Spectate-Mode nicht verfügbar.';
+        button.title = 'Im aktuellen Modus nicht verfügbar.';
         button.classList.add('is-disabled');
       } else {
         button.classList.remove('is-disabled');

--- a/src/ui/root.ts
+++ b/src/ui/root.ts
@@ -5,9 +5,12 @@ import type {
   WarcallResolution,
   WorldState
 } from '@sim/types';
+import { createElement } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
 import type { Highlight } from '@state/cycleDigest';
 import type { GameStore } from '@state/store';
 import type { GameMode, UIModeState, UIModeStore } from '@state/ui/mode';
+import { FreeRoamView } from '@/features/freeRoam/FreeRoamView';
 import {
   selectWarcallsByStatus,
   statusOf,
@@ -77,11 +80,14 @@ const SORT_OPTIONS: { value: UIFilters['sortBy']; label: string }[] = [
 
 export class NemesisUI {
   private root: HTMLElement | null = null;
+  private appRoot: HTMLDivElement | null = null;
   private ranksEl: HTMLElement | null = null;
   private feedEl: HTMLElement | null = null;
   private warcallsHost: HTMLElement | null = null;
   private modeIndicator: HTMLElement | null = null;
   private warcallButton: HTMLButtonElement | null = null;
+  private freeRoamContainer: HTMLDivElement | null = null;
+  private freeRoamRoot: Root | null = null;
   private readonly cards = new Map<string, OfficerCard>();
   private readonly rankContainers = new Map<Rank, HTMLElement>();
   private readonly filters = new UIFilterStore();
@@ -228,6 +234,7 @@ export class NemesisUI {
     this.applyModeToControls();
     this.syncModeIndicator();
     this.syncModeAttributes();
+    this.syncModeLayout();
     this.warcallModal.setMode(this.modeState.mode);
   }
 
@@ -236,10 +243,11 @@ export class NemesisUI {
     const disabled = this.modeState.mode !== 'player';
     this.warcallButton.disabled = disabled;
     if (disabled) {
-      this.warcallButton.setAttribute(
-        'title',
-        'Im Spectate-Mode nicht verfügbar.'
-      );
+      const reason =
+        this.modeState.mode === 'freeRoam'
+          ? 'Im Free-Roam-Modus nicht verfügbar.'
+          : 'Im Spectate-Mode nicht verfügbar.';
+      this.warcallButton.setAttribute('title', reason);
     } else {
       this.warcallButton.removeAttribute('title');
     }
@@ -247,10 +255,12 @@ export class NemesisUI {
 
   private syncModeIndicator(): void {
     if (!this.modeIndicator) return;
-    const label =
-      this.modeState.mode === 'player'
-        ? 'Player-Modus (Beta)'
-        : 'Spectate-Modus';
+    let label = 'Spectate-Modus';
+    if (this.modeState.mode === 'player') {
+      label = 'Player-Modus (Beta)';
+    } else if (this.modeState.mode === 'freeRoam') {
+      label = 'Free Roam (Test)';
+    }
     this.modeIndicator.textContent = label;
   }
 
@@ -260,6 +270,48 @@ export class NemesisUI {
     }
     if (typeof document !== 'undefined' && document.body) {
       document.body.dataset.gameMode = this.modeState.mode;
+    }
+  }
+
+  private syncModeLayout(): void {
+    const isFreeRoam = this.modeState.mode === 'freeRoam';
+    if (this.appRoot) {
+      if (isFreeRoam) {
+        this.appRoot.setAttribute('hidden', 'true');
+        this.appRoot.setAttribute('aria-hidden', 'true');
+      } else {
+        this.appRoot.removeAttribute('hidden');
+        this.appRoot.removeAttribute('aria-hidden');
+      }
+    }
+    if (isFreeRoam) {
+      this.openFreeRoam();
+    } else {
+      this.closeFreeRoam();
+    }
+  }
+
+  private openFreeRoam(): void {
+    if (!this.freeRoamContainer) return;
+    if (!this.freeRoamRoot) {
+      this.freeRoamRoot = createRoot(this.freeRoamContainer);
+    }
+    this.freeRoamContainer.hidden = false;
+    this.freeRoamRoot.render(
+      createElement(FreeRoamView, {
+        store: this.store,
+        modeStore: this.modeStore
+      })
+    );
+  }
+
+  private closeFreeRoam(): void {
+    if (this.freeRoamContainer) {
+      this.freeRoamContainer.hidden = true;
+    }
+    if (this.freeRoamRoot) {
+      this.freeRoamRoot.unmount();
+      this.freeRoamRoot = null;
     }
   }
 
@@ -286,7 +338,12 @@ export class NemesisUI {
         <aside class="feed" id="feed"></aside>
       </main>
     `;
+    this.appRoot = app;
     root.appendChild(app);
+    this.freeRoamContainer = document.createElement('div');
+    this.freeRoamContainer.className = 'free-roam-shell';
+    this.freeRoamContainer.hidden = true;
+    root.appendChild(this.freeRoamContainer);
     this.highlightPortal.attach(document.body);
 
     this.ranksEl = app.querySelector('#ranks');
@@ -500,7 +557,11 @@ export class NemesisUI {
 
   private scheduleWarcall(): void {
     if (this.modeState.mode !== 'player') {
-      this.rememberHint('n-disabled', 'Im Spectate-Mode nicht verfügbar.');
+      const message =
+        this.modeState.mode === 'freeRoam'
+          ? 'Im Free-Roam-Modus nicht verfügbar.'
+          : 'Im Spectate-Mode nicht verfügbar.';
+      this.rememberHint('n-disabled', message);
       return;
     }
     this.store.scheduleWarcall();

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -1761,3 +1761,247 @@ button:disabled {
     max-height: 240px;
   }
 }
+
+/* Free Roam */
+.free-roam-shell {
+  height: 100%;
+}
+
+.free-roam {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  width: 100%;
+  background:
+    radial-gradient(
+      circle at 20% 25%,
+      rgba(59, 130, 246, 0.2),
+      transparent 60%
+    ),
+    radial-gradient(
+      circle at 80% 70%,
+      rgba(248, 113, 113, 0.18),
+      transparent 65%
+    ),
+    var(--bg-base);
+  color: var(--text-primary);
+}
+
+.free-roam__hud {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--spacing-lg);
+  padding: 20px 28px;
+  border-bottom: 1px solid var(--border-strong);
+  background: rgba(13, 17, 23, 0.94);
+  backdrop-filter: blur(18px);
+  box-shadow: 0 14px 24px rgba(8, 13, 23, 0.4);
+  flex-wrap: wrap;
+}
+
+.free-roam__title h1 {
+  margin: 0;
+  font-size: 1.6rem;
+  letter-spacing: 0.04em;
+}
+
+.free-roam__title p {
+  margin: 4px 0 0;
+  color: var(--text-muted);
+  max-width: 460px;
+}
+
+.free-roam__status {
+  display: flex;
+  gap: var(--spacing-lg);
+  font-weight: 600;
+  font-size: 0.95rem;
+  flex-wrap: wrap;
+}
+
+.free-roam__actions {
+  display: flex;
+  gap: var(--spacing-sm);
+}
+
+.free-roam__body {
+  flex: 1;
+  min-height: 0;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(260px, 340px);
+  gap: var(--spacing-lg);
+  padding: var(--spacing-lg);
+  align-items: stretch;
+}
+
+.free-roam__stage {
+  position: relative;
+  border-radius: 20px;
+  overflow: hidden;
+  border: 1px solid var(--border-strong);
+  background:
+    radial-gradient(
+      circle at 28% 32%,
+      rgba(59, 130, 246, 0.12),
+      transparent 65%
+    ),
+    radial-gradient(
+      circle at 72% 68%,
+      rgba(248, 113, 113, 0.12),
+      transparent 70%
+    ),
+    rgba(10, 16, 26, 0.95);
+  min-height: 0;
+  display: flex;
+}
+
+.free-roam__canvas {
+  flex: 1;
+  width: 100%;
+  height: 100%;
+  display: block;
+  image-rendering: pixelated;
+  image-rendering: crisp-edges;
+}
+
+.free-roam__overlay {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  font-size: 0.75rem;
+}
+
+.free-roam__marker {
+  position: absolute;
+  transform: translate(-50%, -50%);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  pointer-events: auto;
+  text-align: center;
+}
+
+.free-roam__marker--warcall {
+  z-index: 4;
+}
+
+.free-roam__marker--officer {
+  z-index: 3;
+}
+
+.free-roam__marker-avatar {
+  border-radius: 14px;
+  border: 2px solid rgba(148, 163, 184, 0.45);
+  box-shadow: 0 12px 20px rgba(9, 12, 19, 0.55);
+}
+
+.free-roam__marker-label {
+  padding: 2px 8px;
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.8);
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  color: var(--text-primary);
+  font-size: 0.7rem;
+  white-space: nowrap;
+  box-shadow: 0 6px 10px rgba(8, 13, 23, 0.4);
+}
+
+.free-roam__marker-icon {
+  width: 34px;
+  height: 34px;
+  border-radius: 50%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: #f8fafc;
+  font-size: 0.95rem;
+  box-shadow: 0 10px 18px rgba(8, 13, 23, 0.5);
+  background: rgba(239, 68, 68, 0.9);
+}
+
+.free-roam__marker--warcall.free-roam__marker--prep .free-roam__marker-icon {
+  background: rgba(99, 102, 241, 0.9);
+}
+
+.free-roam__marker--warcall.free-roam__marker--travel .free-roam__marker-icon {
+  background: rgba(14, 165, 233, 0.92);
+}
+
+.free-roam__marker--warcall.free-roam__marker--event .free-roam__marker-icon {
+  background: rgba(249, 115, 22, 0.95);
+}
+
+.free-roam__marker--warcall.free-roam__marker--resolution
+  .free-roam__marker-icon {
+  background: rgba(34, 197, 94, 0.92);
+}
+
+.free-roam__sidebar {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-lg);
+  min-width: 0;
+}
+
+.free-roam__panel {
+  background: rgba(15, 23, 42, 0.82);
+  border: 1px solid var(--border-strong);
+  border-radius: 18px;
+  padding: var(--spacing-lg);
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-sm);
+  min-height: 0;
+}
+
+.free-roam__panel h2 {
+  margin: 0;
+  font-size: 1rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.free-roam__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-sm);
+  overflow-y: auto;
+  max-height: 45vh;
+}
+
+.free-roam__list-item {
+  padding: 10px 12px;
+  background: rgba(30, 41, 59, 0.6);
+  border-radius: 12px;
+  border: 1px solid rgba(51, 65, 85, 0.55);
+  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.05);
+}
+
+.free-roam__list-title {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  align-items: baseline;
+}
+
+.free-roam__list-title strong {
+  font-weight: 600;
+}
+
+.free-roam__list-meta {
+  margin-top: 4px;
+  color: var(--text-muted);
+  font-size: 0.75rem;
+}
+
+.free-roam__empty {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 0.85rem;
+}


### PR DESCRIPTION
## Summary
- add the Free Roam (Test) mode to the mode gate and UI store so it can be selected alongside Spectate and Player
- implement a React-based FreeRoamView backed by the real simulation, including idle-cycle triggering and a procedural 256×256 biome map
- introduce reusable map generation, rendering, navigation helpers, and selectors plus styling for the standalone free roam experience

## Testing
- npm run lint
- npm run typecheck
- npm run test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d1ec33e2f8832096f58b42c969a0fc