### PR TITLE
Add interactive Free Roam (Test) modal

### DIFF
--- a/src/features/freeRoam/FreeRoamView.tsx
+++ b/src/features/freeRoam/FreeRoamView.tsx
@@ -1,6 +1,16 @@
-import { useEffect, useMemo, useRef } from 'react';
+import type {
+  MouseEvent as ReactMouseEvent,
+  PointerEvent as ReactPointerEvent,
+  WheelEvent as ReactWheelEvent
+} from 'react';
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState
+} from 'react';
 import type { GameStore } from '@state/store';
-import type { UIModeStore } from '@state/ui/mode';
 import type { Phase } from '@state/selectors/warcalls';
 import Portrait from '@/ui/Portrait';
 import { renderWorldMap } from '@/map/render';
@@ -32,10 +42,35 @@ const BIOME_LABEL: Record<Biome, string> = {
 
 interface FreeRoamViewProps {
   store: GameStore;
-  modeStore: UIModeStore;
+  onRequestClose: () => void;
+  onHighlightHostChange?: (element: HTMLElement | null) => void;
 }
 
-export function FreeRoamView({ store, modeStore }: FreeRoamViewProps) {
+interface CameraState {
+  scale: number;
+  x: number;
+  y: number;
+}
+
+const MIN_SCALE = 0.6;
+const MAX_SCALE = 2.75;
+
+function clamp(value: number, min: number, max: number): number {
+  if (value < min) return min;
+  if (value > max) return max;
+  return value;
+}
+
+function formatIdleCountdown(idleMs: number, idleSeconds: number): number {
+  const totalSeconds = Math.ceil(idleMs / 1000);
+  return Math.max(0, totalSeconds - idleSeconds);
+}
+
+export function FreeRoamView({
+  store,
+  onRequestClose,
+  onHighlightHostChange
+}: FreeRoamViewProps) {
   const idleMs = DEFAULT_IDLE_MS;
   const { map, warcalls, officers, cycle, idleSeconds } = useFreeRoam(store, {
     mapSize: DEFAULT_MAP_SIZE,
@@ -44,6 +79,25 @@ export function FreeRoamView({ store, modeStore }: FreeRoamViewProps) {
   });
 
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const stageRef = useRef<HTMLDivElement | null>(null);
+  const highlightHostRef = useRef<HTMLDivElement | null>(null);
+  const closeButtonRef = useRef<HTMLButtonElement | null>(null);
+  const pointerState = useRef<{
+    pointerId: number | null;
+    startX: number;
+    startY: number;
+    originX: number;
+    originY: number;
+    isDragging: boolean;
+  }>({
+    pointerId: null,
+    startX: 0,
+    startY: 0,
+    originX: 0,
+    originY: 0,
+    isDragging: false
+  });
+  const [camera, setCamera] = useState<CameraState>({ scale: 1, x: 0, y: 0 });
 
   useEffect(() => {
     const canvas = canvasRef.current;
@@ -51,77 +105,240 @@ export function FreeRoamView({ store, modeStore }: FreeRoamViewProps) {
     renderWorldMap(canvas, map);
   }, [map]);
 
-  const secondsUntilCycle = useMemo(() => {
-    const total = Math.ceil(idleMs / 1000);
-    return Math.max(0, total - idleSeconds);
-  }, [idleMs, idleSeconds]);
+  useEffect(() => {
+    if (typeof document === 'undefined') return undefined;
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    return () => {
+      document.body.style.overflow = previousOverflow;
+    };
+  }, []);
 
-  const handleExit = () => {
-    modeStore.setMode('spectate');
-  };
+  useEffect(() => {
+    if (!onHighlightHostChange) return undefined;
+    const host = highlightHostRef.current;
+    onHighlightHostChange(host);
+    return () => {
+      onHighlightHostChange(null);
+    };
+  }, [onHighlightHostChange]);
 
-  const handleAdvanceCycle = () => {
+  useEffect(() => {
+    closeButtonRef.current?.focus({ preventScroll: true });
+  }, []);
+
+  useEffect(() => {
+    const handleKeydown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        onRequestClose();
+      }
+    };
+    window.addEventListener('keydown', handleKeydown);
+    return () => window.removeEventListener('keydown', handleKeydown);
+  }, [onRequestClose]);
+
+  const secondsUntilCycle = useMemo(
+    () => formatIdleCountdown(idleMs, idleSeconds),
+    [idleMs, idleSeconds]
+  );
+
+  const handleAdvanceCycle = useCallback(() => {
     store.tick();
-  };
+  }, [store]);
+
+  const handleResetCamera = useCallback(() => {
+    setCamera({ scale: 1, x: 0, y: 0 });
+  }, []);
+
+  const handlePointerDown = useCallback(
+    (event: ReactPointerEvent<HTMLDivElement>) => {
+      const stage = stageRef.current;
+      if (!stage) return;
+      stage.setPointerCapture(event.pointerId);
+      pointerState.current = {
+        pointerId: event.pointerId,
+        startX: event.clientX,
+        startY: event.clientY,
+        originX: camera.x,
+        originY: camera.y,
+        isDragging: true
+      };
+    },
+    [camera]
+  );
+
+  const handlePointerMove = useCallback((event: ReactPointerEvent<HTMLDivElement>) => {
+    const state = pointerState.current;
+    if (!state.isDragging || state.pointerId !== event.pointerId) {
+      return;
+    }
+    const deltaX = event.clientX - state.startX;
+    const deltaY = event.clientY - state.startY;
+    setCamera((prev) => {
+      if (!state.isDragging) return prev;
+      const nextX = state.originX + deltaX;
+      const nextY = state.originY + deltaY;
+      if (prev.x === nextX && prev.y === nextY) {
+        return prev;
+      }
+      return { ...prev, x: nextX, y: nextY };
+    });
+  }, []);
+
+  const stopDragging = useCallback(() => {
+    const state = pointerState.current;
+    if (!state.isDragging) return;
+    pointerState.current = {
+      pointerId: null,
+      startX: 0,
+      startY: 0,
+      originX: 0,
+      originY: 0,
+      isDragging: false
+    };
+  }, []);
+
+  const handlePointerUp = useCallback(
+    (event: ReactPointerEvent<HTMLDivElement>) => {
+      const stage = stageRef.current;
+      if (stage && stage.hasPointerCapture(event.pointerId)) {
+        stage.releasePointerCapture(event.pointerId);
+      }
+      stopDragging();
+    },
+    [stopDragging]
+  );
+
+  const handleWheel = useCallback(
+    (event: ReactWheelEvent<HTMLDivElement>) => {
+      if (!stageRef.current) return;
+      event.preventDefault();
+      const scaleFactor = event.deltaY < 0 ? 1.12 : 0.88;
+      setCamera((prev) => {
+        const nextScale = clamp(prev.scale * scaleFactor, MIN_SCALE, MAX_SCALE);
+        if (nextScale === prev.scale) {
+          return prev;
+        }
+        const rect = stageRef.current?.getBoundingClientRect();
+        if (!rect) {
+          return { ...prev, scale: nextScale };
+        }
+        const offsetX = event.clientX - rect.left - rect.width / 2;
+        const offsetY = event.clientY - rect.top - rect.height / 2;
+        const scaleDelta = nextScale / prev.scale;
+        const nextX = prev.x - offsetX * (scaleDelta - 1);
+        const nextY = prev.y - offsetY * (scaleDelta - 1);
+        if (nextX === prev.x && nextY === prev.y && nextScale === prev.scale) {
+          return prev;
+        }
+        return { scale: nextScale, x: nextX, y: nextY };
+      });
+    },
+    []
+  );
+
+  const handleBackdropClick = useCallback(
+    (event: ReactMouseEvent<HTMLDivElement>) => {
+      if (event.target !== event.currentTarget) return;
+      onRequestClose();
+    },
+    [onRequestClose]
+  );
+
+  const secondsLabel = useMemo(() => `${secondsUntilCycle}s`, [secondsUntilCycle]);
+
+  const viewportStyle = useMemo(
+    () => ({
+      transform: `translate(${camera.x}px, ${camera.y}px) scale(${camera.scale})`,
+      transformOrigin: 'center center'
+    }),
+    [camera]
+  );
 
   return (
-    <div className="free-roam">
+    <div
+      className="free-roam"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="free-roam-title"
+      onClick={handleBackdropClick}
+    >
       <header className="free-roam__hud">
         <div className="free-roam__title">
-          <h1>Free Roam (Test)</h1>
+          <h1 id="free-roam-title">Free Roam (Test)</h1>
           <p>Erkunde die Nemesis-Simulation direkt auf der Weltkarte.</p>
         </div>
         <div className="free-roam__status">
           <span>Zyklus {cycle}</span>
-          <span>Nächster Auto-Cycle in {secondsUntilCycle}s</span>
+          <span>Nächster Auto-Cycle in {secondsLabel}</span>
         </div>
         <div className="free-roam__actions">
           <button type="button" onClick={handleAdvanceCycle}>
             Cycle auslösen
           </button>
-          <button type="button" onClick={handleExit}>
+          <button type="button" onClick={handleResetCamera}>
+            Kamera zurücksetzen
+          </button>
+          <button
+            type="button"
+            onClick={onRequestClose}
+            ref={closeButtonRef}
+          >
             Zurück
           </button>
         </div>
       </header>
       <div className="free-roam__body">
-        <div className="free-roam__stage">
-          <canvas ref={canvasRef} className="free-roam__canvas" />
-          <div className="free-roam__overlay">
-            {warcalls.map((entry) => (
-              <div
-                key={entry.warcall.id}
-                className={`free-roam__marker free-roam__marker--warcall free-roam__marker--${entry.warcall.phase}`}
-                style={{
-                  left: `${entry.xPercent}%`,
-                  top: `${entry.yPercent}%`
-                }}
-                title={`${entry.warcall.kind} — ${entry.warcall.location}`}
-              >
-                <span className="free-roam__marker-icon">⚔️</span>
-              </div>
-            ))}
-            {officers.map((entry) => (
-              <div
-                key={entry.officer.id}
-                className="free-roam__marker free-roam__marker--officer"
-                style={{
-                  left: `${entry.xPercent}%`,
-                  top: `${entry.yPercent}%`
-                }}
-                title={`${entry.officer.name} • ${BIOME_LABEL[entry.coordinate.biome]}`}
-              >
-                <Portrait
-                  officer={entry.officer}
-                  size={48}
-                  className="free-roam__marker-avatar"
-                />
-                <span className="free-roam__marker-label">
-                  {entry.officer.name}
-                </span>
-              </div>
-            ))}
+        <div
+          className="free-roam__stage"
+          ref={stageRef}
+          onPointerDown={handlePointerDown}
+          onPointerMove={handlePointerMove}
+          onPointerUp={handlePointerUp}
+          onPointerCancel={handlePointerUp}
+          onPointerLeave={stopDragging}
+          onWheel={handleWheel}
+        >
+          <div className="free-roam__viewport" style={viewportStyle}>
+            <canvas ref={canvasRef} className="free-roam__canvas" />
+            <div className="free-roam__overlay">
+              {warcalls.map((entry) => (
+                <div
+                  key={entry.warcall.id}
+                  className={`free-roam__marker free-roam__marker--warcall free-roam__marker--${entry.warcall.phase}`}
+                  style={{
+                    left: `${entry.xPercent}%`,
+                    top: `${entry.yPercent}%`
+                  }}
+                  title={`${entry.warcall.kind} — ${entry.warcall.location}`}
+                >
+                  <span className="free-roam__marker-icon">⚔️</span>
+                </div>
+              ))}
+              {officers.map((entry) => (
+                <div
+                  key={entry.officer.id}
+                  className="free-roam__marker free-roam__marker--officer"
+                  style={{
+                    left: `${entry.xPercent}%`,
+                    top: `${entry.yPercent}%`
+                  }}
+                  title={`${entry.officer.name} • ${BIOME_LABEL[entry.coordinate.biome]}`}
+                >
+                  <Portrait
+                    officer={entry.officer}
+                    size={48}
+                    className="free-roam__marker-avatar"
+                  />
+                  <span className="free-roam__marker-label">
+                    {entry.officer.name}
+                  </span>
+                </div>
+              ))}
+            </div>
           </div>
+          <div ref={highlightHostRef} className="free-roam__highlight-host" />
         </div>
         <aside className="free-roam__sidebar">
           <section className="free-roam__panel">

--- a/src/features/freeRoam/FreeRoamView.tsx
+++ b/src/features/freeRoam/FreeRoamView.tsx
@@ -3,13 +3,7 @@ import type {
   PointerEvent as ReactPointerEvent,
   WheelEvent as ReactWheelEvent
 } from 'react';
-import {
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState
-} from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { GameStore } from '@state/store';
 import type { Phase } from '@state/selectors/warcalls';
 import Portrait from '@/ui/Portrait';
@@ -168,23 +162,26 @@ export function FreeRoamView({
     [camera]
   );
 
-  const handlePointerMove = useCallback((event: ReactPointerEvent<HTMLDivElement>) => {
-    const state = pointerState.current;
-    if (!state.isDragging || state.pointerId !== event.pointerId) {
-      return;
-    }
-    const deltaX = event.clientX - state.startX;
-    const deltaY = event.clientY - state.startY;
-    setCamera((prev) => {
-      if (!state.isDragging) return prev;
-      const nextX = state.originX + deltaX;
-      const nextY = state.originY + deltaY;
-      if (prev.x === nextX && prev.y === nextY) {
-        return prev;
+  const handlePointerMove = useCallback(
+    (event: ReactPointerEvent<HTMLDivElement>) => {
+      const state = pointerState.current;
+      if (!state.isDragging || state.pointerId !== event.pointerId) {
+        return;
       }
-      return { ...prev, x: nextX, y: nextY };
-    });
-  }, []);
+      const deltaX = event.clientX - state.startX;
+      const deltaY = event.clientY - state.startY;
+      setCamera((prev) => {
+        if (!state.isDragging) return prev;
+        const nextX = state.originX + deltaX;
+        const nextY = state.originY + deltaY;
+        if (prev.x === nextX && prev.y === nextY) {
+          return prev;
+        }
+        return { ...prev, x: nextX, y: nextY };
+      });
+    },
+    []
+  );
 
   const stopDragging = useCallback(() => {
     const state = pointerState.current;
@@ -210,33 +207,30 @@ export function FreeRoamView({
     [stopDragging]
   );
 
-  const handleWheel = useCallback(
-    (event: ReactWheelEvent<HTMLDivElement>) => {
-      if (!stageRef.current) return;
-      event.preventDefault();
-      const scaleFactor = event.deltaY < 0 ? 1.12 : 0.88;
-      setCamera((prev) => {
-        const nextScale = clamp(prev.scale * scaleFactor, MIN_SCALE, MAX_SCALE);
-        if (nextScale === prev.scale) {
-          return prev;
-        }
-        const rect = stageRef.current?.getBoundingClientRect();
-        if (!rect) {
-          return { ...prev, scale: nextScale };
-        }
-        const offsetX = event.clientX - rect.left - rect.width / 2;
-        const offsetY = event.clientY - rect.top - rect.height / 2;
-        const scaleDelta = nextScale / prev.scale;
-        const nextX = prev.x - offsetX * (scaleDelta - 1);
-        const nextY = prev.y - offsetY * (scaleDelta - 1);
-        if (nextX === prev.x && nextY === prev.y && nextScale === prev.scale) {
-          return prev;
-        }
-        return { scale: nextScale, x: nextX, y: nextY };
-      });
-    },
-    []
-  );
+  const handleWheel = useCallback((event: ReactWheelEvent<HTMLDivElement>) => {
+    if (!stageRef.current) return;
+    event.preventDefault();
+    const scaleFactor = event.deltaY < 0 ? 1.12 : 0.88;
+    setCamera((prev) => {
+      const nextScale = clamp(prev.scale * scaleFactor, MIN_SCALE, MAX_SCALE);
+      if (nextScale === prev.scale) {
+        return prev;
+      }
+      const rect = stageRef.current?.getBoundingClientRect();
+      if (!rect) {
+        return { ...prev, scale: nextScale };
+      }
+      const offsetX = event.clientX - rect.left - rect.width / 2;
+      const offsetY = event.clientY - rect.top - rect.height / 2;
+      const scaleDelta = nextScale / prev.scale;
+      const nextX = prev.x - offsetX * (scaleDelta - 1);
+      const nextY = prev.y - offsetY * (scaleDelta - 1);
+      if (nextX === prev.x && nextY === prev.y && nextScale === prev.scale) {
+        return prev;
+      }
+      return { scale: nextScale, x: nextX, y: nextY };
+    });
+  }, []);
 
   const handleBackdropClick = useCallback(
     (event: ReactMouseEvent<HTMLDivElement>) => {
@@ -246,7 +240,10 @@ export function FreeRoamView({
     [onRequestClose]
   );
 
-  const secondsLabel = useMemo(() => `${secondsUntilCycle}s`, [secondsUntilCycle]);
+  const secondsLabel = useMemo(
+    () => `${secondsUntilCycle}s`,
+    [secondsUntilCycle]
+  );
 
   const viewportStyle = useMemo(
     () => ({
@@ -280,11 +277,7 @@ export function FreeRoamView({
           <button type="button" onClick={handleResetCamera}>
             Kamera zurücksetzen
           </button>
-          <button
-            type="button"
-            onClick={onRequestClose}
-            ref={closeButtonRef}
-          >
+          <button type="button" onClick={onRequestClose} ref={closeButtonRef}>
             Zurück
           </button>
         </div>

--- a/src/ui/root.ts
+++ b/src/ui/root.ts
@@ -88,6 +88,7 @@ export class NemesisUI {
   private warcallButton: HTMLButtonElement | null = null;
   private freeRoamContainer: HTMLDivElement | null = null;
   private freeRoamRoot: Root | null = null;
+  private freeRoamHighlightHost: HTMLElement | null = null;
   private readonly cards = new Map<string, OfficerCard>();
   private readonly rankContainers = new Map<Rank, HTMLElement>();
   private readonly filters = new UIFilterStore();
@@ -291,6 +292,15 @@ export class NemesisUI {
     }
   }
 
+  private setFreeRoamHighlightHost(host: HTMLElement | null): void {
+    this.freeRoamHighlightHost = host;
+    if (host) {
+      this.highlightPortal.attach(host);
+    } else if (typeof document !== 'undefined' && document.body) {
+      this.highlightPortal.attach(document.body);
+    }
+  }
+
   private openFreeRoam(): void {
     if (!this.freeRoamContainer) return;
     if (!this.freeRoamRoot) {
@@ -301,7 +311,8 @@ export class NemesisUI {
     this.freeRoamRoot.render(
       createElement(FreeRoamView, {
         store: this.store,
-        modeStore: this.modeStore
+        onRequestClose: () => this.modeStore.setMode('spectate'),
+        onHighlightHostChange: (host) => this.setFreeRoamHighlightHost(host)
       })
     );
   }
@@ -310,6 +321,9 @@ export class NemesisUI {
     if (this.freeRoamContainer) {
       this.freeRoamContainer.hidden = true;
       this.freeRoamContainer.setAttribute('aria-hidden', 'true');
+    }
+    if (this.freeRoamHighlightHost) {
+      this.setFreeRoamHighlightHost(null);
     }
     if (this.freeRoamRoot) {
       this.freeRoamRoot.unmount();
@@ -346,6 +360,14 @@ export class NemesisUI {
     this.freeRoamContainer.className = 'free-roam-shell';
     this.freeRoamContainer.hidden = true;
     this.freeRoamContainer.setAttribute('aria-hidden', 'true');
+    this.freeRoamContainer.addEventListener('click', (event) => {
+      if (
+        event.target === this.freeRoamContainer &&
+        this.modeState.mode === 'freeRoam'
+      ) {
+        this.modeStore.setMode('spectate');
+      }
+    });
     root.appendChild(this.freeRoamContainer);
     this.highlightPortal.attach(document.body);
 

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -1772,9 +1772,16 @@ button:disabled {
 
 /* Free Roam */
 .free-roam-shell {
-  height: 100%;
-  width: 100%;
+  position: fixed;
+  inset: 0;
   display: flex;
+  align-items: stretch;
+  justify-content: center;
+  padding: clamp(16px, 3vw, 48px);
+  background: rgba(6, 12, 24, 0.78);
+  backdrop-filter: blur(18px);
+  z-index: 48;
+  box-sizing: border-box;
 }
 
 .free-roam {
@@ -1782,6 +1789,10 @@ button:disabled {
   flex-direction: column;
   height: 100%;
   width: 100%;
+  max-width: 1440px;
+  margin: 0 auto;
+  border-radius: 28px;
+  overflow: hidden;
   background:
     radial-gradient(
       circle at 20% 25%,
@@ -1864,6 +1875,27 @@ button:disabled {
     rgba(10, 16, 26, 0.95);
   min-height: 0;
   display: flex;
+  touch-action: none;
+  cursor: grab;
+  user-select: none;
+}
+
+.free-roam__stage:active {
+  cursor: grabbing;
+}
+
+.free-roam__viewport {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  transform-origin: center center;
+  will-change: transform;
+}
+
+.free-roam__highlight-host {
+  position: absolute;
+  inset: 0;
+  z-index: 6;
 }
 
 .free-roam__canvas {


### PR DESCRIPTION
## Summary
- rebuild the Free Roam (Test) experience as a fullscreen modal with pan/zoom camera controls, idle-cycle countdown, and officer/warcall overlays
- rewire the UI shell so the highlight portal mounts inside the modal and background clicks/ESC close the view without affecting Spectate
- refresh Free Roam styles to provide a dedicated overlay backdrop and stage affordances for panning

## Testing
- npm run lint
- npm run typecheck
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d723dc05a48320a931f64f7228207d